### PR TITLE
chore: disabled codecov comment and patch

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,23 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: no
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment: off


### PR DESCRIPTION
This PR disabled CodeCov's patch check and bot comment