### PR TITLE
fix: avoid overwriting Atlas state with undefined tiles

### DIFF
--- a/src/components/Atlas/Atlas.tsx
+++ b/src/components/Atlas/Atlas.tsx
@@ -90,7 +90,7 @@ export class Atlas extends React.PureComponent<AtlasProps, AtlasState> {
   }
 
   componentWillReceiveProps(nextProps: AtlasProps) {
-    if (nextProps.tiles !== this.state.tiles) {
+    if (nextProps.tiles && nextProps.tiles !== this.state.tiles) {
       this.setState({ tiles: nextProps.tiles })
     }
   }


### PR DESCRIPTION
Closes #42