### PR TITLE
feat: added support for error and message props in SelectField

### DIFF
--- a/src/components/SelectField/SelectField.css
+++ b/src/components/SelectField/SelectField.css
@@ -91,3 +91,32 @@
 .dcl.select-field .ui.selection.active.dropdown {
   box-shadow: none;
 }
+
+/* Error */
+
+.dcl.select-field.error .ui.selection.dropdown {
+  border-bottom: 2px solid var(--error);
+}
+
+.dcl.select-field.error .message {
+  color: var(--error);
+}
+
+.dcl.select-field.error .ui.header.sub {
+  color: var(--error);
+}
+
+.dcl.select-field.error .ui.selection.dropdown > i.icon {
+  opacity: 1;
+  background: url('../../assets/alert.svg');
+  background-repeat: no-repeat;
+  background-position: left center;
+  padding-left: 32px;
+  height: 36px;
+}
+
+.dcl.select-field.error .ui.selection.dropdown > i.icon:before {
+  /* content: '';
+  display: none; */
+  color: var(--error);
+}

--- a/src/components/SelectField/SelectField.stories.tsx
+++ b/src/components/SelectField/SelectField.stories.tsx
@@ -20,6 +20,33 @@ storiesOf('SelectField', module)
       />
     </>
   ))
+  .add('Message', () => (
+    <SelectField
+      label="Label"
+      placeholder="Placeholder"
+      message="Additional comment"
+      options={[
+        { key: 1, text: 'Choice 1', value: 1 },
+        { key: 2, text: 'Choice 2', value: 2 },
+        { key: 3, text: 'Choice 3', value: 3 }
+      ]}
+      onChange={(_, a) => console.log(a)}
+    />
+  ))
+  .add('Error', () => (
+    <SelectField
+      label="Label"
+      placeholder="Placeholder"
+      message="Some warning"
+      error
+      options={[
+        { key: 1, text: 'Choice 1', value: 1 },
+        { key: 2, text: 'Choice 2', value: 2 },
+        { key: 3, text: 'Choice 3', value: 3 }
+      ]}
+      onChange={(_, a) => console.log(a)}
+    />
+  ))
   .add('Disabled options', () => (
     <>
       <SelectField

--- a/src/components/SelectField/SelectField.tsx
+++ b/src/components/SelectField/SelectField.tsx
@@ -5,13 +5,19 @@ import './SelectField.css'
 
 export type SelectFieldProps = DropdownProps & {
   label?: string
+  error?: boolean
+  message?: string
   header?: JSX.Element
 }
 
 export class SelectField extends React.PureComponent<SelectFieldProps> {
   render() {
-    const { label, header, options, ...rest } = this.props
-    const classes = 'dcl select-field'
+    const { label, header, options, message, error, ...rest } = this.props
+    let classes = 'dcl select-field'
+
+    if (error) {
+      classes += ' error warning circle'
+    }
 
     return (
       <div className={classes}>
@@ -33,7 +39,10 @@ export class SelectField extends React.PureComponent<SelectFieldProps> {
             </Dropdown.Menu>
           </Dropdown.Menu>
         </Dropdown>
-        <p className="message">&nbsp;</p>
+        <p className="message">
+          {message}
+          &nbsp;
+        </p>
       </div>
     )
   }

--- a/src/components/SelectField/SelectField.tsx
+++ b/src/components/SelectField/SelectField.tsx
@@ -23,9 +23,9 @@ export class SelectField extends React.PureComponent<SelectFieldProps> {
       <div className={classes}>
         {label ? <Header sub>{label}</Header> : null}
 
-        <Dropdown search selection {...rest}>
-          <Dropdown.Menu className="wrapper">
-            {header}
+        <Dropdown search selection options={options} {...rest}>
+          {header && <Dropdown.Menu className="wrapper">
+            <Dropdown.Header content={header} />
             <Dropdown.Menu scrolling className="options-wrapper">
               {options.map((opt, i) => (
                 <Dropdown.Item
@@ -37,7 +37,7 @@ export class SelectField extends React.PureComponent<SelectFieldProps> {
                 />
               ))}
             </Dropdown.Menu>
-          </Dropdown.Menu>
+          </Dropdown.Menu>}
         </Dropdown>
         <p className="message">
           {message}


### PR DESCRIPTION
- [x] add support for `message=string` prop
<img width="449" alt="Screen Shot 2020-06-02 at 11 10 40" src="https://user-images.githubusercontent.com/208789/83530340-fa1bf100-a4c1-11ea-9743-653bfd2ff356.png">

- [x] add support for `error=boolean` prop
<img width="441" alt="Screen Shot 2020-06-02 at 11 10 45" src="https://user-images.githubusercontent.com/208789/83530457-22a3eb00-a4c2-11ea-8af2-f8a01a340a17.png">

- [x] fix filtering value
<img width="472" alt="Screen Shot 2020-06-02 at 11 55 26" src="https://user-images.githubusercontent.com/208789/83535267-2fc3d880-a4c8-11ea-8e12-85687cdfc58e.png">
