### PR TITLE
fix: stretched buttons on firefox

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -1,6 +1,6 @@
 .ui.button {
   font-style: normal;
-  font-stretch: expanded;
+  font-stretch: normal;
   letter-spacing: normal;
   text-transform: uppercase;
   font-family: var(--font-family);


### PR DESCRIPTION
This PR fixes the styles of buttons on firefox

Before:
<img width="533" alt="Screen Shot 2021-10-18 at 1 15 29 PM" src="https://user-images.githubusercontent.com/2781777/137769741-cf2ef2bf-d619-475c-b195-0f0383857444.png">

After:
<img width="443" alt="Screen Shot 2021-10-18 at 1 15 40 PM" src="https://user-images.githubusercontent.com/2781777/137769759-3edfd80a-0ec6-4584-af34-191ecfd91c3f.png">


