### PR TITLE
fix: image import on css

### DIFF
--- a/src/components/Loader/Loader.css
+++ b/src/components/Loader/Loader.css
@@ -15,13 +15,13 @@
 }
 
 .ui.loader.injected {
-  background-image: url('../../images/metamask.svg');
+  background-image: inline('../../images/metamask.svg');
 }
 
 .ui.loader.formatic {
-  background-image: url('../../images/fortmatic.png');
+  background-image: inline('../../images/fortmatic.png');
 }
 
 .ui.loader.wallet_connect {
-  background-image: url('../../images/wallet-connect.png');
+  background-image: inline('../../images/wallet-connect.png');
 }

--- a/src/components/LoginModal/LoginModal.css
+++ b/src/components/LoginModal/LoginModal.css
@@ -28,7 +28,7 @@
 }
 
 .dcl.option.metamask .image {
-  background-image: url('../../images/metamask.svg');
+  background-image: inline('../../images/metamask.svg');
 }
 
 .dcl.option.dapper .image {


### PR DESCRIPTION
This PR replace the use of `url(...)` for `inline(...)` to prevent compilation fails on some frameworks:

<img width="1012" alt="Screen Shot 2022-01-05 at 14 40 49" src="https://user-images.githubusercontent.com/208789/148263572-cc16e429-5cae-4bb7-89dd-00765f9f9fd5.png">

