### PR TITLE
feat: send updates via postMessage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 .vscode
 node_modules
-lib
+/lib
 dist
 storybook-static
 coverage/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,9 +1328,9 @@
       "dev": true
     },
     "@dcl/schemas": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-3.9.0.tgz",
-      "integrity": "sha512-1UBT8GF9STf/RxloRzc0vnIEf5xL7qZl2amhvTQvEXXCPmAmeOKz9kuMCSplzAXlKuHeN3atl6ePxTBZPzBqOQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.3.0.tgz",
+      "integrity": "sha512-r82OdfnFOgoiO41ASxPofzNsngKs8UbySF7rV3QwYXzRsKcphkPxlXee6isA4IJaxVwkWTeuVTDw3VDLWlF0Jg==",
       "requires": {
         "ajv": "^7.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {
-    "@dcl/schemas": "^3.9.0",
+    "@dcl/schemas": "^4.3.0",
     "balloon-css": "^0.5.0",
     "ethereum-blockies": "^0.1.1",
     "parallax-js": "^3.1.0",

--- a/src/components/WearablePreview/WearablePreview.stories.tsx
+++ b/src/components/WearablePreview/WearablePreview.stories.tsx
@@ -8,10 +8,28 @@ import {
   Navbar,
   Page,
   Tabs,
-  WearablePreview,
-  AvatarEmote
+  WearablePreview
 } from '../..'
 import './WearablePreview.stories.css'
+import { PreviewCamera, PreviewEmote, WearableBodyShape } from '@dcl/schemas'
+
+const getRandomHex = () => {
+  return '#' + Math.random().toString(16).slice(2, 8)
+}
+
+const RandomConfigProvider = (props: {
+  children: (hair: string, skin: string) => React.ReactElement
+}) => {
+  const [hair, setHair] = React.useState(getRandomHex())
+  const [skin, setSkin] = React.useState(getRandomHex())
+  React.useEffect(() => {
+    setInterval(() => {
+      setHair(getRandomHex())
+      setSkin(getRandomHex())
+    }, 5000)
+  }, [])
+  return props.children(hair, skin)
+}
 
 storiesOf('WearablePreview', module)
   .add('Preview an item', () => (
@@ -71,7 +89,7 @@ storiesOf('WearablePreview', module)
         contractAddress="0xe3d2c4ec777fb88dd219905cd896f79a592adf30"
         itemId="0"
         hair="00ff00"
-        bodyShape="female"
+        bodyShape={WearableBodyShape.FEMALE}
       />
     </div>
   ))
@@ -84,7 +102,7 @@ storiesOf('WearablePreview', module)
     <div className="WearablePreview-story-container">
       <WearablePreview
         profile="0xc85a0a34d5f9f2239ab0622a41a2c2560ff119c6"
-        emote={AvatarEmote.FASHION}
+        emote={PreviewEmote.FASHION}
       />
     </div>
   ))
@@ -94,7 +112,7 @@ storiesOf('WearablePreview', module)
         contractAddress="0x186c788f9c172934b790b868faf3b78b84e34e89"
         itemId="0"
         profile="0xc85a0a34d5f9f2239ab0622a41a2c2560ff119c6"
-        emote={AvatarEmote.FASHION}
+        emote={PreviewEmote.FASHION}
       />
     </div>
   ))
@@ -102,7 +120,7 @@ storiesOf('WearablePreview', module)
     <div className="WearablePreview-story-container">
       <WearablePreview
         profile="0xc85a0a34d5f9f2239ab0622a41a2c2560ff119c6"
-        camera="static"
+        camera={PreviewCamera.STATIC}
       />
     </div>
   ))
@@ -145,5 +163,19 @@ storiesOf('WearablePreview', module)
         </Container>
       </Page>
       <Footer />
+    </div>
+  ))
+  .add('With hot reload', () => (
+    <div className="WearablePreview-story-container">
+      <RandomConfigProvider>
+        {(hair, skin) => (
+          <WearablePreview
+            profile="default"
+            hair={hair}
+            skin={skin}
+            onLoad={() => console.log('loaded!')}
+          />
+        )}
+      </RandomConfigProvider>
     </div>
   ))

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,0 +1,13 @@
+export function createDebounce() {
+  let timeout = null
+  return (
+    fn: (...args: unknown[]) => unknown,
+    ms: number,
+    ...args: unknown[]
+  ) => {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+    timeout = setTimeout(fn, ms, ...args)
+  }
+}


### PR DESCRIPTION
This PR adds support to changing props in the `WearablePreview` component without refreshing the iframe. To do this, the URL of the iframe is stored in the component's state when it's mounted, and is never updated again even if the props are changed, this preserves the iframe between renders. In order to communicate the updated properties to the iframe, this is done passing messages using `postMessage`. These messages are debounced 500ms to batch multiple changes together in a single update.

This PR also upgraded to the latest `@dcl/schemas` version and uses the shared preview types.

I also added some properties that were already supported on the `wearable-preview` app but were not wired in the `WearablePreview` component, like `autoRotateSpeed`, `offsetX`, `offsetY`, `offsetZ`, `transparentBackground`.