### PR TITLE
feat: add fullwidth style to match docs design request

### DIFF
--- a/src/components/Container/Container.css
+++ b/src/components/Container/Container.css
@@ -2,6 +2,12 @@
   .ui.container {
     width: 1064px;
   }
+
+  .ui.container.full-width {
+    width: 100%;
+    padding: 0 24px;
+    box-sizing: border-box;
+  }
 }
 
 @media (max-width: 768px) {

--- a/src/components/Footer/Footer.stories.css
+++ b/src/components/Footer/Footer.stories.css
@@ -1,0 +1,3 @@
+.Footer-fullwidth-container {
+  width: 1200px;
+}

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -2,10 +2,16 @@ import * as React from 'react'
 import { storiesOf } from '@storybook/react'
 import centered from '@storybook/addon-centered/react'
 import { Footer } from './Footer'
+import './Footer.stories.css'
 
 storiesOf('Footer', module)
   .addDecorator(centered)
   .add('Uncontrolled', () => <Footer />)
   .add('Controlled', () => (
     <Footer locale="en" locales={['en', 'es', 'fr', 'ja', 'ko', 'zh']} />
+  ))
+  .add('Full width inner container', () => (
+    <div className="Footer-fullwidth-container">
+      <Footer isFullWidth />
+    </div>
   ))

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -53,8 +53,15 @@ export class Footer extends React.PureComponent<FooterProps> {
   }
 
   render(): JSX.Element {
-    const { locale, locales, onChange, i18n, isFullscreen, className, isFullWidth } =
-      this.props
+    const {
+      locale,
+      locales,
+      onChange,
+      i18n,
+      isFullscreen,
+      className,
+      isFullWidth
+    } = this.props
 
     let classes = 'dcl footer'
     if (isFullscreen) {

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -28,6 +28,7 @@ export type FooterProps = {
   onChange?: LanguageDropdownProps['onChange']
   isFullscreen?: boolean
   className?: string
+  isFullWidth?: boolean
 }
 
 export class Footer extends React.PureComponent<FooterProps> {
@@ -52,7 +53,7 @@ export class Footer extends React.PureComponent<FooterProps> {
   }
 
   render(): JSX.Element {
-    const { locale, locales, onChange, i18n, isFullscreen, className } =
+    const { locale, locales, onChange, i18n, isFullscreen, className, isFullWidth } =
       this.props
 
     let classes = 'dcl footer'
@@ -61,6 +62,9 @@ export class Footer extends React.PureComponent<FooterProps> {
     }
     if (className) {
       classes += ' ' + className
+    }
+    if (isFullWidth) {
+      classes += ' full-width'
     }
 
     return (

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -203,3 +203,10 @@ storiesOf('Navbar', module)
       </div>
     )
   })
+  .add('Full width inner container', () => {
+    return (
+      <div className="Navbar-story-container">
+        <Navbar isFullWidth activePage="dao" />
+      </div>
+    )
+  })

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -48,6 +48,7 @@ export type NavbarProps = {
   className?: string
   onSignIn?: () => void
   onClickAccount?: () => void
+  isFullWidth?: boolean
 }
 
 export type NavbarState = {
@@ -82,7 +83,8 @@ export class Navbar extends React.PureComponent<NavbarProps, NavbarState> {
     isOverlay: false,
     isSignIn: false,
     onSignIn: null,
-    onClickAccount: null
+    onClickAccount: null,
+    isFullWidth: false
   }
   public state = {
     toggle: false
@@ -210,7 +212,7 @@ export class Navbar extends React.PureComponent<NavbarProps, NavbarState> {
   }
 
   render(): JSX.Element {
-    const { activePage, className, isSignIn, isFullscreen, isOverlay } =
+    const { activePage, className, isSignIn, isFullscreen, isOverlay, isFullWidth } =
       this.props
 
     let classes = `dcl navbar`
@@ -237,7 +239,7 @@ export class Navbar extends React.PureComponent<NavbarProps, NavbarState> {
 
     return (
       <div className={classes} role="navigation">
-        <Container>
+        <Container className={isFullWidth && "full-width"}>
           <div className="dcl navbar-menu">
             <NotMobile>
               <Menu secondary stackable>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -212,8 +212,14 @@ export class Navbar extends React.PureComponent<NavbarProps, NavbarState> {
   }
 
   render(): JSX.Element {
-    const { activePage, className, isSignIn, isFullscreen, isOverlay, isFullWidth } =
-      this.props
+    const {
+      activePage,
+      className,
+      isSignIn,
+      isFullscreen,
+      isOverlay,
+      isFullWidth
+    } = this.props
 
     let classes = `dcl navbar`
 
@@ -239,7 +245,7 @@ export class Navbar extends React.PureComponent<NavbarProps, NavbarState> {
 
     return (
       <div className={classes} role="navigation">
-        <Container className={isFullWidth && "full-width"}>
+        <Container className={isFullWidth && 'full-width'}>
           <div className="dcl navbar-menu">
             <NotMobile>
               <Menu secondary stackable>


### PR DESCRIPTION
Added fullWidth prop for navbar / footer components to match new docs site design:
https://www.figma.com/file/qJabYQmkRIQWMLRbGRCvj9/Documentation?node-id=1454%3A4509

<img width="977" alt="image" src="https://user-images.githubusercontent.com/33739951/162519762-1bdcc220-52a4-4879-ba13-d16d673f357f.png">
