### PR TITLE
fix: @dcl/schemas imports

### DIFF
--- a/src/components/AvatarFace/AvatarFace.tsx
+++ b/src/components/AvatarFace/AvatarFace.tsx
@@ -1,5 +1,5 @@
-import { Avatar } from '@dcl/schemas'
 import * as React from 'react'
+import { Avatar } from '@dcl/schemas/dist/platform/profile/avatar'
 import './AvatarFace.css'
 
 export type AvatarFaceProps = {

--- a/src/components/Mana/Mana.stories.tsx
+++ b/src/components/Mana/Mana.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { storiesOf } from '@storybook/react'
 import centered from '@storybook/addon-centered/react'
-import { Network } from '@dcl/schemas'
+import { Network } from '@dcl/schemas/dist/dapps/network'
 import { Header } from '../Header/Header'
 import { Mana } from './Mana'
 

--- a/src/components/Mana/Mana.tsx
+++ b/src/components/Mana/Mana.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Network } from '@dcl/schemas'
+import { Network } from '@dcl/schemas/dist/dapps/network'
 import { Header, HeaderProps } from '../Header/Header'
 import './Mana.css'
 

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Avatar } from '@dcl/schemas'
+import { Avatar } from '@dcl/schemas/dist/platform/profile/avatar'
 import { Logo } from '../Logo/Logo'
 import { Popup } from '../Popup/Popup'
 import { AvatarFace } from '../AvatarFace/AvatarFace'

--- a/src/components/UserMenu/UserMenu.stories.tsx
+++ b/src/components/UserMenu/UserMenu.stories.tsx
@@ -1,5 +1,5 @@
-import { Network } from '@dcl/schemas'
 import * as React from 'react'
+import { Network } from '@dcl/schemas/dist/dapps/network'
 import MenuItem from 'semantic-ui-react/dist/commonjs/collections/Menu/MenuItem'
 import Icon from 'semantic-ui-react/dist/commonjs/elements/Icon/Icon'
 import { storiesOf } from '@storybook/react'

--- a/src/components/UserMenu/UserMenu.tsx
+++ b/src/components/UserMenu/UserMenu.tsx
@@ -1,5 +1,6 @@
-import { Avatar, Network } from '@dcl/schemas'
 import * as React from 'react'
+import { Network } from '@dcl/schemas/dist/dapps/network'
+import { Avatar } from '@dcl/schemas/dist/platform/profile/avatar'
 import Menu from 'semantic-ui-react/dist/commonjs/collections/Menu'
 import Icon from 'semantic-ui-react/dist/commonjs/elements/Icon'
 import { AvatarFace } from '../AvatarFace/AvatarFace'

--- a/src/components/WearablePreview/WearablePreview.stories.tsx
+++ b/src/components/WearablePreview/WearablePreview.stories.tsx
@@ -1,17 +1,16 @@
 import * as React from 'react'
 import { storiesOf } from '@storybook/react'
-import {
-  Container,
-  Footer,
-  Header,
-  Hero,
-  Navbar,
-  Page,
-  Tabs,
-  WearablePreview
-} from '../..'
+import { PreviewCamera, PreviewEmote } from '@dcl/schemas/dist/dapps/preview'
+import { WearableBodyShape } from '@dcl/schemas/dist/platform/wearables'
+import { WearablePreview } from './WearablePreview'
+import { Navbar } from '../Navbar/Navbar'
+import { Tabs } from '../Tabs/Tabs'
+import { Page } from '../Page/Page'
+import { Hero } from '../Hero/Hero'
+import { Container } from '../Container/Container'
+import { Header } from '../Header/Header'
+import { Footer } from '../Footer/Footer'
 import './WearablePreview.stories.css'
-import { PreviewCamera, PreviewEmote, WearableBodyShape } from '@dcl/schemas'
 
 const getRandomHex = () => {
   return '#' + Math.random().toString(16).slice(2, 8)

--- a/src/components/WearablePreview/WearablePreview.tsx
+++ b/src/components/WearablePreview/WearablePreview.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable  @typescript-eslint/no-empty-function */
 import * as React from 'react'
-import { PreviewCamera, PreviewEmote, PreviewEnv, PreviewOptions } from '@dcl/schemas/dist/dapps/preview'
+import {
+  PreviewCamera,
+  PreviewEmote,
+  PreviewEnv,
+  PreviewOptions
+} from '@dcl/schemas/dist/dapps/preview'
 import { WearableBodyShape } from '@dcl/schemas/dist/platform/wearables'
 import { createDebounce } from '../../lib/debounce'
 import './WearablePreview.css'

--- a/src/components/WearablePreview/WearablePreview.tsx
+++ b/src/components/WearablePreview/WearablePreview.tsx
@@ -1,12 +1,7 @@
 /* eslint-disable  @typescript-eslint/no-empty-function */
-import {
-  PreviewCamera,
-  PreviewEmote,
-  PreviewEnv,
-  PreviewOptions,
-  WearableBodyShape
-} from '@dcl/schemas'
 import * as React from 'react'
+import { PreviewCamera, PreviewEmote, PreviewEnv, PreviewOptions } from '@dcl/schemas/dist/dapps/preview'
+import { WearableBodyShape } from '@dcl/schemas/dist/platform/wearables'
 import { createDebounce } from '../../lib/debounce'
 import './WearablePreview.css'
 

--- a/src/data/avatar.ts
+++ b/src/data/avatar.ts
@@ -1,4 +1,4 @@
-import { Avatar } from '@dcl/schemas'
+import { Avatar } from "@dcl/schemas/dist/platform/profile/avatar";
 
 export const avatar: Avatar = {
   userId: '0xb6e9c0a25aa6b10fa4fe0aa8d1097d2a6136bf98',

--- a/src/data/avatar.ts
+++ b/src/data/avatar.ts
@@ -1,4 +1,4 @@
-import { Avatar } from "@dcl/schemas/dist/platform/profile/avatar";
+import { Avatar } from '@dcl/schemas/dist/platform/profile/avatar'
 
 export const avatar: Avatar = {
   userId: '0xb6e9c0a25aa6b10fa4fe0aa8d1097d2a6136bf98',


### PR DESCRIPTION
## Context

some browsers are getting the following error when we import directly from `@dcl/schemas`

```
Uncaught SyntaxError: Invalid flags supplied to RegExp constructor 'u'
```

## Solution

This PR replace all directs imports from `@dcl/schemas` in favor of each specific file to prevent this error and also reduce the bundle size of the library