### PR TITLE
feat(WearablePreview): integrate ready message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,9 +1328,9 @@
       "dev": true
     },
     "@dcl/schemas": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.5.0.tgz",
-      "integrity": "sha512-kFKT/pxlhtu5HQ4BhrHer6A024hjupG4qRWq0HnKHbtxMshsFCiqsSlb62647mz5Oht9ueBqwL2R9GYg8ALAUQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.8.0.tgz",
+      "integrity": "sha512-NLvu90JSAunwA6vVYfVcdvlwO2x5fTc2tPhsko5kFfBEIp7lCzwSy6DoSlee/t92Uw9zIyNIS9Ai3ewLQ0T4zQ==",
       "requires": {
         "ajv": "^7.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {
-    "@dcl/schemas": "^4.5.0",
+    "@dcl/schemas": "^4.8.0",
     "balloon-css": "^0.5.0",
     "ethereum-blockies": "^0.1.1",
     "parallax-js": "^3.1.0",

--- a/src/components/WearablePreview/WearablePreview.tsx
+++ b/src/components/WearablePreview/WearablePreview.tsx
@@ -45,6 +45,8 @@ export type WearablePreviewProps = {
 
 export type WearablePreviewState = {
   url?: string
+  isReady: boolean
+  pendingOptions: PreviewOptions | null
 }
 
 export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
@@ -55,7 +57,10 @@ export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
     onError: () => {}
   }
 
-  state: WearablePreviewState = {}
+  state: WearablePreviewState = {
+    isReady: false,
+    pendingOptions: null
+  }
 
   iframe: HTMLIFrameElement | null = null
 
@@ -182,6 +187,24 @@ export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
             onError(new Error(payload.message))
             break
           }
+          case PreviewMessageType.READY: {
+            const { pendingOptions } = this.state
+            if (pendingOptions != null) {
+              // if there were pending options, flush them and flag as ready
+              sendMessage(
+                this.iframe.contentWindow,
+                PreviewMessageType.UPDATE,
+                {
+                  options: pendingOptions
+                }
+              )
+              this.setState({ isReady: true, pendingOptions: null })
+            } else {
+              // otherwise just flag as ready
+              this.setState({ isReady: true })
+            }
+            break
+          }
           default:
           // do nothing
         }
@@ -194,9 +217,15 @@ export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
       // SSR check
       if (window) {
         const options = this.getOptions()
-        sendMessage(this.iframe.contentWindow, PreviewMessageType.UPDATE, {
-          options
-        })
+        if (this.state.isReady) {
+          // if the iframe is ready, send the update
+          sendMessage(this.iframe.contentWindow, PreviewMessageType.UPDATE, {
+            options
+          })
+        } else {
+          // otherwise store last update in state until it's ready
+          this.setState({ pendingPreviewOptions: options })
+        }
       }
     } else {
       console.warn(`Could not send update, iframe is not referenced`)

--- a/src/components/WearablePreview/WearablePreview.tsx
+++ b/src/components/WearablePreview/WearablePreview.tsx
@@ -43,7 +43,7 @@ export type WearablePreviewProps = {
   onError?: (error: Error) => void
 }
 
-export type WearablePreviewState = {
+type WearablePreviewState = {
   url?: string
   isReady: boolean
   pendingOptions: PreviewOptions | null

--- a/src/components/WearablePreview/WearablePreview.tsx
+++ b/src/components/WearablePreview/WearablePreview.tsx
@@ -188,7 +188,11 @@ export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
             break
           }
           case PreviewMessageType.READY: {
-            const { pendingOptions } = this.state
+            const { isReady, pendingOptions } = this.state
+            // ignore if already flagged as ready
+            if (isReady) {
+              return
+            }
             if (pendingOptions != null) {
               // if there were pending options, flush them and flag as ready
               sendMessage(

--- a/src/components/WearablePreview/WearablePreview.tsx
+++ b/src/components/WearablePreview/WearablePreview.tsx
@@ -193,7 +193,7 @@ export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
             if (isReady) {
               return
             }
-            if (pendingOptions != null) {
+            if (pendingOptions !== null) {
               // if there were pending options, flush them and flag as ready
               sendMessage(
                 this.iframe.contentWindow,


### PR DESCRIPTION
This PR integrates the `ready` message from the wearable-preview iframe (for reference: https://github.com/decentraland/wearable-preview/pull/31). It keeps track of the ready-ness of the iframe with a boolean in state, and the updates that arrive before the iframe is ready are stored in state too (only the last update is kept in state since each update overrides the previous ones). Once the `ready` message arrives, if there was any pending update stored in state it is flushed back to the iframe. This way messages sent while the iframe is loading are not lost.