### PR TITLE
feat(WearablePreview): controller RPC integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,22 +1328,37 @@
       "dev": true
     },
     "@dcl/schemas": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.9.0.tgz",
-      "integrity": "sha512-KLSXhTkmfRIOHk11/8RcP/2i1TOspBjeWfIZyQzliKm2VKnHCHMz186VGtghJnw9MczctDAU49D8rV/atuXZAQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.3.0.tgz",
+      "integrity": "sha512-OslfXpMzrBbgoQvFDeLkvODsD39k8dhrSCz/w9J3NkE6rSgZ3ZgTP9rYyVX/quiFcaXTYrD6Tp33eHechj7KHg==",
       "requires": {
-        "ajv": "^7.1.0"
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-          "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2",
             "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ=="
+        },
+        "ajv-keywords": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3"
           }
         },
         "fast-deep-equal": {
@@ -10325,6 +10340,11 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
+    },
+    "fp-future": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fp-future/-/fp-future-1.0.1.tgz",
+      "integrity": "sha512-2McmZH/KsZqlqHju9+Ox0FC7q7Knve4t6ZeKubbhAz1xpnD7hkCrP8TP5g5QbbD5bA5jBANbXf/ew4x1FjSUrw=="
     },
     "fragment-cache": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -72,10 +72,11 @@
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {
-    "@dcl/schemas": "^4.9.0",
+    "@dcl/schemas": "^5.3.0",
     "balloon-css": "^0.5.0",
     "deep-equal": "^2.0.5",
     "ethereum-blockies": "^0.1.1",
+    "fp-future": "^1.0.1",
     "parallax-js": "^3.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/WearablePreview/WearablePreview.controller.ts
+++ b/src/components/WearablePreview/WearablePreview.controller.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  IPreviewController,
+  PreviewMessagePayload,
+  PreviewMessageType,
+  sendMessage
+} from '@dcl/schemas/dist/dapps/preview'
+import { Metrics } from '@dcl/schemas/dist/platform/item/metrics'
+import future, { IFuture } from 'fp-future'
+
+const promises = new Map<string, IFuture<any>>()
+
+window.onmessage = function handleMessage(event: MessageEvent) {
+  if (
+    event.data &&
+    event.data.type &&
+    event.data.type === PreviewMessageType.CONTROLLER_RESPONSE
+  ) {
+    const payload = event.data
+      .payload as PreviewMessagePayload<PreviewMessageType.CONTROLLER_RESPONSE>
+    const { id } = payload
+    const promise = promises.get(id)
+    if (promise) {
+      if (payload.ok) {
+        promise.resolve(payload.result)
+      } else if (payload.ok === false) {
+        promise.reject(new Error(payload.error))
+      }
+    }
+  }
+}
+
+function createSendRequest(id: string) {
+  let nonce = 0
+  return function sendRequest<T>(
+    namespace: 'scene' | 'emote',
+    method:
+      | 'getScreenshot'
+      | 'getMetrics'
+      | 'getLength'
+      | 'isPlaying'
+      | 'goTo'
+      | 'play'
+      | 'pause'
+      | 'stop',
+    params: any[]
+  ) {
+    const iframe = document.getElementById(id) as HTMLIFrameElement
+    const messageId = id + '-' + nonce
+    const promise = future<T>()
+    promises.set(messageId, promise)
+    const type = PreviewMessageType.CONTROLLER_REQUEST
+    const message = { id: messageId, namespace, method, params }
+    sendMessage(iframe.contentWindow, type, message)
+    nonce++
+    return promise
+  }
+}
+
+export function createController(id: string): IPreviewController {
+  if (!document.getElementById(id)) {
+    throw new Error(`Could not find an iframe with id="${id}"`)
+  }
+
+  const sendRequest = createSendRequest(id)
+
+  return {
+    scene: {
+      getScreenshot(width: number, height: number) {
+        return sendRequest<string>('scene', 'getScreenshot', [width, height])
+      },
+      getMetrics() {
+        return sendRequest<Metrics>('scene', 'getMetrics', [])
+      }
+    },
+    emote: {
+      getLength() {
+        return sendRequest<number>('emote', 'getLength', [])
+      },
+      isPlaying() {
+        return sendRequest<boolean>('emote', 'isPlaying', [])
+      },
+      goTo(seconds: number) {
+        return sendRequest<void>('emote', 'goTo', [seconds])
+      },
+      play() {
+        return sendRequest<void>('emote', 'play', [])
+      },
+      pause() {
+        return sendRequest<void>('emote', 'pause', [])
+      },
+      stop() {
+        return sendRequest<void>('emote', 'stop', [])
+      }
+    }
+  }
+}

--- a/src/components/WearablePreview/WearablePreview.stories.css
+++ b/src/components/WearablePreview/WearablePreview.stories.css
@@ -7,3 +7,43 @@
 .WearablePreview-story-container .dcl.hero {
   padding: 0px;
 }
+
+.WearablePreview-story-container .controls {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+}
+
+.WearablePreview-story-container .controls * + * {
+  margin-left: 10px;
+}
+
+.WearablePreview-story-container .controls img {
+  position: absolute;
+  top: 54px;
+  border: 1px solid var(--primary);
+  border-radius: 8px;
+  margin-left: 0px;
+  background-color: #ffffff;
+  width: 256px;
+  height: 256px;
+}
+
+.WearablePreview-story-container .controls .seconds {
+  height: 42px;
+  width: 84px;
+  border-radius: 8px 0px 0px 8px;
+  border: none;
+  padding-left: 12px;
+  outline: none;
+}
+
+.WearablePreview-story-container .dcl.sliderfield .dcl.sliderfield-header,
+.WearablePreview-story-container .dcl.sliderfield p {
+  display: none;
+}
+
+.WearablePreview-story-container .controls .goto {
+  margin-left: 0px;
+  border-radius: 0px 8px 8px 0px;
+}

--- a/src/components/WearablePreview/WearablePreview.tsx
+++ b/src/components/WearablePreview/WearablePreview.tsx
@@ -63,7 +63,7 @@ type WearablePreviewState = {
 export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
   static defaultProps = {
     dev: false,
-    baseUrl: 'https://wearable-preview.decentraland.org/',
+    baseUrl: 'https://wearable-preview.decentraland.org',
     onLoad: () => {},
     onError: () => {},
     onUpdate: () => {}


### PR DESCRIPTION
This PR adds the integration against the `wearable-preview` [controller RPC](https://github.com/decentraland/wearable-preview#controller-rpc).

I also added support for a `blob` property which is now supported by the `wearable-preview`.

I added 4 stories illustrating how to use the new features like taking screenshots, showing metrics, controlling an emote animation and rendering wearables/emotes from zip files