### PR TITLE
feat(WearablePreview): support custom background color

### DIFF
--- a/src/components/WearablePreview/WearablePreview.stories.tsx
+++ b/src/components/WearablePreview/WearablePreview.stories.tsx
@@ -248,6 +248,11 @@ storiesOf('WearablePreview', module)
       <WearablePreview profile="default" disableBackground />
     </div>
   ))
+  .add('With custom background color', () => (
+    <div className="WearablePreview-story-container">
+      <WearablePreview profile="default" background="ff0000" />
+    </div>
+  ))
   .add('Take screenshot and metrics', () => {
     const [screenshot, setScreenshot] = React.useState('')
     const [metrics, setMetrics] = React.useState<Metrics | null>(null)

--- a/src/components/WearablePreview/WearablePreview.tsx
+++ b/src/components/WearablePreview/WearablePreview.tsx
@@ -35,6 +35,7 @@ export type WearablePreviewProps = {
   bodyShape?: BodyShape
   camera?: PreviewCamera
   zoom?: number
+  background?: string
   offsetX?: number
   offsetY?: number
   offsetZ?: number
@@ -97,6 +98,7 @@ export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
       emote,
       camera,
       zoom,
+      background,
       offsetX,
       offsetY,
       offsetZ,
@@ -131,6 +133,7 @@ export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
     const emoteParam = emote ? `emote=${emote}` : ''
     const cameraParam = camera ? `camera=${camera}` : ''
     const zoomParam = !isNaN(zoom) ? `zoom=${zoom}` : ''
+    const backgroundParam = skin ? `background=${background}` : ''
     const offsetXParam = !isNaN(offsetX) ? `offsetX=${offsetX}` : ''
     const offsetYParam = !isNaN(offsetY) ? `offsetY=${offsetY}` : ''
     const offsetZParam = !isNaN(offsetZ) ? `offsetZ=${offsetZ}` : ''
@@ -165,6 +168,7 @@ export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
         emoteParam,
         cameraParam,
         zoomParam,
+        backgroundParam,
         offsetXParam,
         offsetYParam,
         offsetZParam,


### PR DESCRIPTION
This PR adds support for the `WearablePreview` component to use the custom background color feature already supported by the `wearable-preview`