### PR TITLE
fix: prevent reseting nonce

### DIFF
--- a/src/components/WearablePreview/WearablePreview.controller.ts
+++ b/src/components/WearablePreview/WearablePreview.controller.ts
@@ -30,8 +30,8 @@ window.onmessage = function handleMessage(event: MessageEvent) {
   }
 }
 
+let nonce = 0
 function createSendRequest(id: string) {
-  let nonce = 0
   return function sendRequest<T>(
     namespace: 'scene' | 'emote',
     method:


### PR DESCRIPTION
Fix issue where two controller for the same iframe are created at different times, and the nonce is reseted, mixing the promises of the requests and responses.