### PR TITLE
chore: upgrade @dcl/schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,9 +1328,9 @@
       "dev": true
     },
     "@dcl/schemas": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.12.0.tgz",
-      "integrity": "sha512-+vgimO2NkdQy/L1K7xM/2lMf8/B8+JS3rjreE9HYpqZOJQEvHIOi35yJev1KB2GIkYH81tJvjv3oJT7bX1YqjA==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.15.0.tgz",
+      "integrity": "sha512-zt9Iz8r2e9l8JYsEO8+OWxtlY+RQwQL/EXNJ1DZ71WjTFqSNOJcAKoIyCMGKUwh84jSptlw+pYD29copESWwCw==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {
-    "@dcl/schemas": "^5.12.0",
+    "@dcl/schemas": "^5.15.0",
     "balloon-css": "^0.5.0",
     "deep-equal": "^2.0.5",
     "ethereum-blockies": "^0.1.1",

--- a/src/components/WearablePreview/WearablePreview.tsx
+++ b/src/components/WearablePreview/WearablePreview.tsx
@@ -4,7 +4,6 @@ import equal from 'deep-equal'
 import {
   PreviewCamera,
   PreviewEmote,
-  PreviewEnv,
   PreviewOptions,
   PreviewMessageType,
   PreviewMessagePayload,
@@ -223,11 +222,10 @@ export class WearablePreview extends React.PureComponent<WearablePreviewProps> {
   }
 
   getOptions = () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { dev, ...rest } = this.props
 
-    const options: PreviewOptions = {
-      env: dev ? PreviewEnv.DEV : PreviewEnv.PROD
-    }
+    const options: PreviewOptions = {}
 
     for (const key in rest) {
       if (typeof rest[key] !== 'function') {


### PR DESCRIPTION
This PR bumps `@dcl/schemas` to the latest version. It removes the now deprecated `PreviewEnv` since now the `wearable-preview` uses `@dcl/ui-env`: https://github.com/decentraland/wearable-preview/pull/54