### PR TITLE
fix: Emotes animation progress length

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,9 +1328,9 @@
       "dev": true
     },
     "@dcl/schemas": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.17.1.tgz",
-      "integrity": "sha512-4UgDwSOQOfu+n2iHz/0qOwRqBH+/6aC7O/2LYCr0/sbT54RDiAc0sks3iJyFI9qR7+mFaxT1GCCCQaeRJWMvMg==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.27.0.tgz",
+      "integrity": "sha512-8nnbaSTyIY0sIBsrAwjQJV44K1yX6TUO3SkhDId3hkLpF3Wr67w0lnfrCi0tW685/ZTRAdgOE3huCqXAgllmTg==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {
-    "@dcl/schemas": "^5.17.1",
+    "@dcl/schemas": "^5.27.0",
     "balloon-css": "^0.5.0",
     "deep-equal": "^2.0.5",
     "ethereum-blockies": "^0.1.1",

--- a/src/components/WearablePreview/EmoteControls.tsx
+++ b/src/components/WearablePreview/EmoteControls.tsx
@@ -59,9 +59,7 @@ export class EmoteControls extends React.PureComponent<
   }
 
   handleAnimationPlaying = async ({ length }) => {
-    if (await this.previewController.emote.isPlaying()) {
-      this.setState({ frame: Math.ceil((length ?? 0) * 100) })
-    }
+    this.setState({ frame: Math.ceil((length ?? 0) * 100) })
   }
 
   async componentDidMount(): Promise<void> {

--- a/src/components/WearablePreview/EmoteControls.tsx
+++ b/src/components/WearablePreview/EmoteControls.tsx
@@ -36,7 +36,7 @@ export class EmoteControls extends React.PureComponent<
     this.setState({ frame: 0 })
   }
 
-  handleAnimationEnd = async () => {
+  handleAnimationEnd = () => {
     const { frame, length } = this.state
     this.setState({
       isPlaying: false,
@@ -58,11 +58,11 @@ export class EmoteControls extends React.PureComponent<
     this.setState({ isPlaying: true, length: emoteLength })
   }
 
-  handleAnimationPlaying = async ({ length }) => {
+  handleAnimationPlaying = ({ length }) => {
     this.setState({ frame: Math.ceil((length ?? 0) * 100) })
   }
 
-  async componentDidMount(): Promise<void> {
+  componentDidMount(): void {
     const { wearablePreviewController } = this.props
 
     const previewController =

--- a/src/components/WearablePreview/EmoteControls.tsx
+++ b/src/components/WearablePreview/EmoteControls.tsx
@@ -58,9 +58,9 @@ export class EmoteControls extends React.PureComponent<
     this.setState({ isPlaying: true, length: emoteLength })
   }
 
-  handleAnimationPlaying = async (data) => {
+  handleAnimationPlaying = async ({ length }) => {
     if (await this.previewController.emote.isPlaying()) {
-      this.setState({ frame: Math.ceil((data ?? 0) * 100) })
+      this.setState({ frame: Math.ceil((length ?? 0) * 100) })
     }
   }
 

--- a/src/components/WearablePreview/WearablePreview.controller.ts
+++ b/src/components/WearablePreview/WearablePreview.controller.ts
@@ -32,10 +32,10 @@ window.onmessage = function handleMessage(event: MessageEvent) {
       case PreviewMessageType.EMOTE_EVENT: {
         const payload = event.data
           .payload as PreviewMessagePayload<PreviewMessageType.EMOTE_EVENT>
-        const { type } = payload
+        const { type, payload: eventPayload } = payload
         const events = emoteEvents.get(event.source)
         if (events && type) {
-          events.emit(type)
+          events.emit(type, eventPayload)
         }
         break
       }


### PR DESCRIPTION
This PR refactorizes the `EmoteControl` component to consume the current frame from the WearablePreview using the event `animation_playing`

depends on: https://github.com/decentraland/common-schemas/pull/143