### PR TITLE
feat: add icon to toast

### DIFF
--- a/src/components/Toast/Toast.css
+++ b/src/components/Toast/Toast.css
@@ -10,6 +10,14 @@
   color: var(--toast-text);
 }
 
+.dcl.toast .toast-info {
+  display: flex;
+}
+
+.dcl.toast .toast-info .toast-icon {
+  margin-right: 15px;
+}
+
 .dcl.toast .dcl.close {
   position: absolute;
   top: 18px;

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { storiesOf } from '@storybook/react'
 import centered from '@storybook/addon-centered/react'
+import Icon from '../../assets/alert.svg'
 
 import { Toast, ToastType } from './Toast'
 import './Toast.stories.css'
@@ -40,4 +41,12 @@ storiesOf('Toast', module)
   ))
   .add('Error toast', () => (
     <Toast type={ToastType.ERROR} title="Error toast" body="ERROR" />
+  ))
+  .add('Toast with icon', () => (
+    <Toast
+      type={ToastType.INFO}
+      title="Toast with icon"
+      body="This toast has an icon"
+      icon={<img src={Icon} />}
+    />
   ))

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -14,6 +14,7 @@ export type ToastProps = {
   body: string | JSX.Element
   closable?: boolean
   timeout?: number
+  icon?: JSX.Element
   onClose?: () => void
 }
 
@@ -56,12 +57,17 @@ export class Toast extends React.PureComponent<ToastProps> {
   }
 
   render(): JSX.Element {
-    const { type = ToastType.INFO, title, body, closable } = this.props
+    const { type = ToastType.INFO, title, body, closable, icon } = this.props
     return (
       <div className={`dcl toast ${type.toLowerCase()}`}>
-        {closable ? <Close small onClick={this.handleClose} /> : null}
-        <div className="title">{title}</div>
-        <div className="body">{body}</div>
+        <div className="toast-info">
+          {icon && <span className="toast-icon">{icon}</span>}
+          <div>
+            {closable ? <Close small onClick={this.handleClose} /> : null}
+            <div className="title">{title}</div>
+            <div className="body">{body}</div>
+          </div>
+        </div>
       </div>
     )
   }

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,2 +1,7 @@
 // @internal
 declare const module
+
+declare module '*.svg' {
+  const content: string
+  export default content
+}


### PR DESCRIPTION
This PR adds the possiblity to set an icon in the toast component. This is an optional property

### with icon
<img width="428" alt="image" src="https://user-images.githubusercontent.com/11800206/206358573-ab91605d-c150-4143-9b32-db847462da27.png">

### without icon
<img width="403" alt="image" src="https://user-images.githubusercontent.com/11800206/206358619-1541ab88-2de7-4b47-809a-9287c2b060a6.png">
