### PR TITLE
feat: add outline to radio and collapsible box

### DIFF
--- a/src/components/Box/Box.css
+++ b/src/components/Box/Box.css
@@ -36,6 +36,10 @@
   margin-left: 10px;
 }
 
+.dcl.box .box-header .collapse-btn:focus {
+  outline: 1px solid white;
+}
+
 .dcl.box .box-header .ui.button.collapse-btn i {
   margin-right: 0;
   color: #736e7d;

--- a/src/components/Radio/Radio.css
+++ b/src/components/Radio/Radio.css
@@ -51,6 +51,11 @@
   margin-left: 16px;
 }
 
+.ui.radio.checkbox input[type='radio'].hidden:focus + label:before {
+  outline: 1px solid white;
+}
+
+
 /* Toggle */
 
 .ui.toggle.checkbox {

--- a/src/components/Radio/Radio.css
+++ b/src/components/Radio/Radio.css
@@ -55,7 +55,6 @@
   outline: 1px solid white;
 }
 
-
 /* Toggle */
 
 .ui.toggle.checkbox {


### PR DESCRIPTION
Add outline on focus to radios and collapsible box chevron

<img width="279" alt="image" src="https://user-images.githubusercontent.com/11800206/212336028-58efd1c3-1447-4d92-acec-6002e42f3624.png">
<img width="162" alt="image" src="https://user-images.githubusercontent.com/11800206/212359847-68803c54-29c0-4373-b51d-b85f992e31dd.png">
