### PR TITLE
feat: Add "isMana" prop to BarChart

### DIFF
--- a/src/components/BarChart/BarChart.stories.tsx
+++ b/src/components/BarChart/BarChart.stories.tsx
@@ -254,3 +254,14 @@ storiesOf('BarChart ', module)
       onChange={onChange}
     />
   ))
+  .add('with MANA currency', () => (
+    <BarChart
+      isMana
+      width={250}
+      data={data}
+      min={'7000'}
+      max={'2000000'}
+      network={Network.ETHEREUM}
+      onChange={onChange}
+    />
+  ))

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -48,6 +48,9 @@ export const BarChart = ({
   onChange,
   min,
   max,
+  minLabel,
+  maxLabel,
+  isMana = false,
   network = Network.ETHEREUM,
   sliderStep = DEFAULT_SLIDER_STEP,
   errorMessage
@@ -235,13 +238,15 @@ export const BarChart = ({
   return (
     <div className="bar-chart">
       <RangeField
+        minLabel={minLabel}
+        maxLabel={maxLabel}
         minProps={{
-          icon: <Mana network={network} />,
+          icon: isMana ? <Mana network={network} /> : null,
           iconPosition: 'left',
           placeholder: 0
         }}
         maxProps={{
-          icon: <Mana network={network} />,
+          icon: isMana ? <Mana network={network} /> : null,
           iconPosition: 'left',
           placeholder: 1000
         }}
@@ -273,7 +278,7 @@ export const BarChart = ({
             >
               <Tooltip
                 cursor={false}
-                content={<BarChartTooltip network={network} />}
+                content={<BarChartTooltip network={network} isMana={isMana} />}
                 position={{ y: 25 }}
               />
               <Bar dataKey="amount" barSize={8}>
@@ -293,8 +298,17 @@ export const BarChart = ({
             onChange={handleRangeChange}
           />
           <div className="bar-chart-input-container">
-            <Mana network={network}>{sliderMinLabel}</Mana>
-            <Mana network={network}>{sliderMaxLabel}</Mana>
+            {isMana ? (
+              <>
+                <Mana network={network}>{sliderMinLabel}</Mana>
+                <Mana network={network}>{sliderMaxLabel}</Mana>
+              </>
+            ) : (
+              <>
+                <span>{sliderMinLabel}</span>
+                <span>{sliderMaxLabel}</span>
+              </>
+            )}
           </div>
           {errorMessage && showMaxError ? (
             <span className="bar-chart-error">{errorMessage}</span>

--- a/src/components/BarChart/BarChart.types.ts
+++ b/src/components/BarChart/BarChart.types.ts
@@ -10,6 +10,9 @@ export type BarChartProps = {
   min: string
   max: string
   network?: Network
+  isMana?: boolean
+  minLabel?: string
+  maxLabel?: string
   errorMessage?: string
   onChange: (value: [string, string]) => void
 }

--- a/src/components/BarChart/BarChartTooltip.tsx
+++ b/src/components/BarChart/BarChartTooltip.tsx
@@ -10,28 +10,40 @@ export type BarChartTooltipProps = {
   }[]
   active?: boolean
   network: Network
+  isMana: boolean
 }
 
 export const BarChartTooltip = ({
   active,
   payload,
-  network
+  network,
+  isMana
 }: BarChartTooltipProps) => {
   if (active && payload && payload.length && payload[0].payload.amount) {
     const values = payload[0].payload.values
     const isLatestRange = values[0] === values[1]
-    const lowerBoundLabel = formatAndRoundNumberString(values[0].toString())
+    const lowerBound = formatAndRoundNumberString(values[0].toString())
+    const lowerBoundLabel = (
+      <span>{isLatestRange ? `${lowerBound}+` : lowerBound}</span>
+    )
+    const upperBoundLabel = (
+      <span>{formatAndRoundNumberString(values[1].toString())}</span>
+    )
     return (
       <div className="custom-tooltip">
-        <Mana network={network}>
-          <span>{isLatestRange ? `${lowerBoundLabel}+` : lowerBoundLabel}</span>
-        </Mana>
+        {isMana ? (
+          <Mana network={network}>{lowerBoundLabel}</Mana>
+        ) : (
+          lowerBoundLabel
+        )}
         {!isLatestRange ? (
           <>
             <span className="custom-tooltip-separator">-</span>
-            <Mana network={network}>
-              <span>{formatAndRoundNumberString(values[1].toString())}</span>
-            </Mana>
+            {isMana ? (
+              <Mana network={network}>{upperBoundLabel}</Mana>
+            ) : (
+              upperBoundLabel
+            )}
           </>
         ) : null}
       </div>


### PR DESCRIPTION
We are gonna use the BarChart for units that are not in MANA, so we should support sending a boolean to avoid rendering the MANA icon 

## With MANA Currency

![image](https://user-images.githubusercontent.com/8763687/217348448-b711a893-fb52-4c71-82e0-df739dabed80.png)

## Without MANA

![image](https://user-images.githubusercontent.com/8763687/217348491-aab63d74-0ce3-4a92-88fe-32a34629592f.png)
