### PR TITLE
feat: make slider accesible

### DIFF
--- a/src/components/BarChart/BarChart.css
+++ b/src/components/BarChart/BarChart.css
@@ -79,29 +79,22 @@
   margin-top: 16px;
 }
 
-.bar-chart .bar-chart-input-container {
-  display: flex;
-  align-items: center;
-  position: relative;
-  justify-content: space-between;
+.bar-chart .dcl.sliderfield-track .slider-value .slider-label {
   font-weight: 400;
   font-size: 13px;
   line-height: 24px;
-  /* identical to box height, or 160% */
-
   letter-spacing: -0.2px;
 
   color: #736e7d;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  position: relative;
+  top: -5px;
+  left: 0;
 }
 
-.bar-chart .bar-chart-input-container .ui.header.dcl.mana {
-  position: relative;
-  margin-bottom: 0;
-  top: 0;
-  left: 0;
+.bar-chart .dcl.sliderfield-track .slider-value .ui.header.dcl.mana {
   font-size: 15px;
 }
 

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -318,20 +318,25 @@ export const BarChart = ({
             max={inputMaxRangeValue}
             step={sliderStep}
             onChange={handleRangeChange}
+            labelFrom={
+              isMana ? (
+                <Mana network={network} className="slider-label">
+                  {sliderMinLabel}
+                </Mana>
+              ) : (
+                <span className="slider-label">{sliderMinLabel}</span>
+              )
+            }
+            labelTo={
+              isMana ? (
+                <Mana network={network} className="slider-label">
+                  {sliderMaxLabel}
+                </Mana>
+              ) : (
+                <span className="slider-label">{sliderMaxLabel}</span>
+              )
+            }
           />
-          <div className="bar-chart-input-container">
-            {isMana ? (
-              <>
-                <Mana network={network}>{sliderMinLabel}</Mana>
-                <Mana network={network}>{sliderMaxLabel}</Mana>
-              </>
-            ) : (
-              <>
-                <span>{sliderMinLabel}</span>
-                <span>{sliderMaxLabel}</span>
-              </>
-            )}
-          </div>
           {errorMessage && showMaxError ? (
             <span className="bar-chart-error">{errorMessage}</span>
           ) : null}

--- a/src/components/SliderField/SliderField.css
+++ b/src/components/SliderField/SliderField.css
@@ -24,6 +24,7 @@
   width: 100%;
   position: relative;
   height: 8px;
+  margin-top: 25px;
 }
 
 .dcl.sliderfield-wrapper .dcl.sliderfield-rail {
@@ -72,15 +73,6 @@
   left: 0;
   cursor: pointer;
 }
-.dcl.sliderfield-wrapper
-  > input[type='range']:focus::-webkit-slider-runnable-track {
-  background: transparent;
-  border: transparent;
-}
-
-.dcl.sliderfield-wrapper > input[type='range']:focus {
-  outline: none;
-}
 
 .dcl.sliderfield-wrapper > input[type='range']::-webkit-slider-thumb {
   pointer-events: all;
@@ -89,6 +81,28 @@
   border-radius: 0px;
   border: 0 none;
   -webkit-appearance: none;
+}
+
+.dcl.sliderfield-wrapper
+  > input[type='range'].sliderfield-input-right:focus
+  ~ .dcl.sliderfield-rail
+  .dcl.sliderfield-mark.right,
+.dcl.sliderfield-wrapper
+  > input[type='range'].sliderfield-input-left:focus
+  ~ .dcl.sliderfield-rail
+  .dcl.sliderfield-mark.left {
+  outline: 1px solid #cfcdd4;
+}
+
+.dcl.sliderfield-wrapper
+  > input[type='range'].sliderfield-input-right:hover
+  ~ .dcl.sliderfield-rail
+  .dcl.sliderfield-mark.right,
+.dcl.sliderfield-wrapper
+  > input[type='range'].sliderfield-input-left:hover
+  ~ .dcl.sliderfield-rail
+  .dcl.sliderfield-mark.left {
+  background: var(--primary-hover);
 }
 
 .dcl.sliderfield-wrapper > input[type='range']::-moz-range-thumb {
@@ -108,4 +122,17 @@
 
 .dcl.sliderfield-wrapper > input[type='range']::-ms-tooltip {
   display: none;
+}
+
+.dcl.sliderfield-track .slider-value {
+  position: absolute;
+  top: -25px;
+}
+
+.dcl.sliderfield-track .slider-from {
+  left: -8px;
+}
+
+.dcl.sliderfield-track .slider-to {
+  right: -3px;
 }

--- a/src/components/SliderField/SliderField.stories.tsx
+++ b/src/components/SliderField/SliderField.stories.tsx
@@ -79,3 +79,30 @@ storiesOf('SliderField', module)
       range
     />
   ))
+  .add('with state', () => {
+    const [value, setRange] = React.useState<number>(10)
+    return (
+      <SliderField
+        header="Shown on console"
+        min={0}
+        max={10}
+        valueFrom={0}
+        valueTo={value}
+        onChange={(_, data) => setRange(data[1])}
+      />
+    )
+  })
+  .add('range with state', () => {
+    const [range, setRange] = React.useState<readonly [number, number]>([0, 10])
+    return (
+      <SliderField
+        header="Shown on console"
+        min={0}
+        max={10}
+        valueFrom={range[0]}
+        valueTo={range[1]}
+        onChange={(_, data) => setRange(data)}
+        range
+      />
+    )
+  })

--- a/src/components/SliderField/SliderField.stories.tsx
+++ b/src/components/SliderField/SliderField.stories.tsx
@@ -93,7 +93,7 @@ storiesOf('SliderField', module)
     )
   })
   .add('range with state', () => {
-    const [range, setRange] = React.useState<readonly [number, number]>([0, 10])
+    const [range, setRange] = React.useState<readonly [number, number]>([5, 10])
     return (
       <SliderField
         header="Shown on console"

--- a/src/components/SliderField/SliderField.tsx
+++ b/src/components/SliderField/SliderField.tsx
@@ -72,14 +72,17 @@ export class SliderField extends React.PureComponent<
   }
 
   componentDidMount(): void {
-    const { defaultValue, min, max } = this.props
+    const { defaultValue, min, max, valueFrom, valueTo } = this.props
 
     if (defaultValue === undefined) {
+      const minValue = !isNaN(min) ? min : SliderDefault.FROM
+      const maxValue = !isNaN(max) ? max : SliderDefault.TO
+
       this.setState((prevState) => {
         return {
           ...prevState,
-          from: !isNaN(min) ? min : prevState.from,
-          to: !isNaN(max) ? max : prevState.to
+          from: valueFrom ? valueFrom : minValue,
+          to: valueTo ? valueTo : maxValue
         }
       })
     } else {

--- a/src/components/SliderField/SliderField.tsx
+++ b/src/components/SliderField/SliderField.tsx
@@ -183,12 +183,6 @@ export class SliderField extends React.PureComponent<
     }
   }
 
-  getLabel = () => {
-    const { label, range } = this.props
-    const { from, to } = this.state
-    return label || (range ? `${from} - ${to}` : to)
-  }
-
   getMarkStyle = (min: number, max: number): SliderFieldLeftRightStyle => {
     const { from, to } = this.state
     const diffMaxMin = max - min


### PR DESCRIPTION
Make slider component accessible following [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb/examples/slider-multithumb/) recommendations 
- Make values of slider follow the thumb and not be static at the sides of the component
- Move labels to the top of the slider to make it more usable for mobile users
- Add roles and labels
<img width="382" alt="image" src="https://user-images.githubusercontent.com/11800206/218367154-1178d069-3e6c-43c6-af1e-834aa95caa06.png">
<img width="351" alt="image" src="https://user-images.githubusercontent.com/11800206/218367195-32f200a4-a23c-4843-b670-006f550be6eb.png">
<img width="251" alt="image" src="https://user-images.githubusercontent.com/11800206/218367245-3a9bf63c-0d43-40b7-9008-70464626ef56.png">
