### PR TITLE
feat(WC2): Override Wallet Connect V2 Modal Styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1334,9 +1334,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.4.2.tgz",
-      "integrity": "sha512-yO8GgC7RIU17951VBGIx2tA0xMVRv6Ia7rR6V97yY77/fYLAIn1FqW/20MEmonDzyJJ5YnuDa/8gVk3XusIXYA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.10.0.tgz",
+      "integrity": "sha512-txmCxm9fczzYPxGjdLXgbYWDuTKhTBszFR8Tyn2F7Q0XAbNV4slzLQ/yVzSfor9qbErieKaeMnsqgn2m45mO+A==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {
-    "@dcl/schemas": "^6.4.2",
+    "@dcl/schemas": "^6.10.0",
     "balloon-css": "^0.5.0",
     "classnames": "^2.3.2",
     "deep-equal": "^2.0.5",

--- a/src/themes/base-theme.css
+++ b/src/themes/base-theme.css
@@ -99,3 +99,10 @@ a:hover {
     --footer-margin-top: 48px;
   }
 }
+
+/* Wallet Connect V2 Modal */
+w3m-modal {
+  position: fixed;
+  /* login-modal is at 3000 */
+  z-index: 3001;
+}


### PR DESCRIPTION
Required because DCL's sign in modal has a z-index of 3000 and shows in front of the wallet connect v2 modal.

By overriding wc2 to 3001 it is fixed.