### PR TITLE
feat: Add the NetworkAlert component

### DIFF
--- a/src/components/Navbar/Navbar.stories.css
+++ b/src/components/Navbar/Navbar.stories.css
@@ -55,3 +55,9 @@
   right: 0px;
   bottom: 0px;
 }
+
+@media (max-width: 768px) {
+  .Navbar-story-container {
+    width: 100%;
+  }
+}

--- a/src/components/NetworkAlert/NetworkAlert.css
+++ b/src/components/NetworkAlert/NetworkAlert.css
@@ -1,7 +1,7 @@
 .NetworkAlert {
   padding-top: 20px;
   padding-bottom: 20px;
-  background-color: #44404B;
+  background-color: #44404b;
   display: flex;
   justify-content: center;
 }

--- a/src/components/NetworkAlert/NetworkAlert.css
+++ b/src/components/NetworkAlert/NetworkAlert.css
@@ -1,0 +1,78 @@
+.NetworkAlert {
+  padding-top: 20px;
+  padding-bottom: 20px;
+  background-color: #44404B;
+  display: flex;
+  justify-content: center;
+}
+
+.NetworkAlert .center {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.NetworkAlert .title {
+  font-weight: bold;
+  white-space: nowrap;
+}
+
+.NetworkAlert .description {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.NetworkAlert .description .ui.header.title {
+  margin: 0 0 5px 0;
+}
+
+.NetworkAlert .description .warning-icon {
+  margin-right: 20px;
+}
+
+.NetworkAlert .action {
+  display: flex;
+  align-items: center;
+  margin-left: 40px;
+}
+
+.NetworkAlert .description a {
+  color: var(--primary-text) !important;
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .NetworkAlert {
+    padding-left: 5%;
+    padding-right: 5%;
+  }
+
+  .NetworkAlert .title {
+    white-space: pre-wrap;
+  }
+
+  .NetworkAlert .center {
+    display: flex;
+    flex-direction: column;
+    justify-content: unset;
+  }
+
+  .NetworkAlert .description {
+    width: 100%;
+  }
+  .NetworkAlert .description .ui.header.title {
+    line-height: normal;
+  }
+
+  .NetworkAlert .action {
+    width: 100%;
+    margin-top: 15px;
+    margin-left: 0px;
+    justify-content: center;
+  }
+
+  .NetworkAlert .action .ui.inverted.button {
+    font-size: 12px;
+  }
+}

--- a/src/components/NetworkAlert/NetworkAlert.stories.tsx
+++ b/src/components/NetworkAlert/NetworkAlert.stories.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { storiesOf } from '@storybook/react'
+import centered from '@storybook/addon-centered/react'
+
+import { Navbar } from '../Navbar/Navbar'
+import { NetworkAlert } from './NetworkAlert'
+import '../Navbar/Navbar.stories.css'
+
+storiesOf('NetworkAlert', module)
+  .addDecorator(centered)
+  .add('Partially supported network', () => {
+    return (
+      <div className="Navbar-story-container">
+        <NetworkAlert onSwitchNetwork={() => undefined} />
+        <Navbar activePage="dao" />
+      </div>
+    )
+  })

--- a/src/components/NetworkAlert/NetworkAlert.tsx
+++ b/src/components/NetworkAlert/NetworkAlert.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import Icon from 'semantic-ui-react/dist/commonjs/elements/Icon'
+import { Button } from '../Button/Button'
+import { Header } from '../Header/Header'
+import { Props } from './NetworkAlert.types'
+import './NetworkAlert.css'
+
+export class NetworkAlert extends React.PureComponent<Props> {
+  static defaultProps = {
+    title:
+      'Your wallet is connected to a partially supported network (Polygon)',
+    content: (
+      <span>
+        Switch to Ethereum Mainnet if you want to use all the features of this
+        app. <a href="">Learn more</a>
+      </span>
+    ),
+    action: 'Switch Network'
+  }
+
+  render() {
+    const { title, content, action, onSwitchNetwork } = this.props
+    return (
+      <div className="NetworkAlert" aria-live="polite">
+        <div className="center">
+          <div className="description">
+            <Icon
+              className="warning-icon"
+              name="warning sign"
+              size="big"
+              color="yellow"
+            />
+            <div>
+              <Header as="h4" className="title">
+                {title}
+              </Header>
+              <p>{content}</p>
+            </div>
+          </div>
+          <div className="action">
+            <Button inverted onClick={onSwitchNetwork}>
+              {action}
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/components/NetworkAlert/NetworkAlert.tsx
+++ b/src/components/NetworkAlert/NetworkAlert.tsx
@@ -7,19 +7,23 @@ import './NetworkAlert.css'
 
 export class NetworkAlert extends React.PureComponent<Props> {
   static defaultProps = {
-    title:
-      'Your wallet is connected to a partially supported network (Polygon)',
-    content: (
-      <span>
-        Switch to Ethereum Mainnet if you want to use all the features of this
-        app. <a href="">Learn more</a>
-      </span>
-    ),
-    action: 'Switch Network'
+    i18n: {
+      title:
+        'Your wallet is connected to a partially supported network (Polygon)',
+      content: (
+        <span>
+          Switch to Ethereum Mainnet if you want to use all the features of this
+          app. <a href="">Learn more</a>
+        </span>
+      ),
+      action: 'Switch Network'
+    }
   }
 
   render() {
-    const { title, content, action, onSwitchNetwork } = this.props
+    const { i18n, onSwitchNetwork } = this.props
+    const { title, content, action } = i18n
+
     return (
       <div className="NetworkAlert" aria-live="polite">
         <div className="center">

--- a/src/components/NetworkAlert/NetworkAlert.types.ts
+++ b/src/components/NetworkAlert/NetworkAlert.types.ts
@@ -1,8 +1,10 @@
 import * as React from 'react'
 
 export type Props = {
-  title?: React.ReactNode
-  content?: React.ReactNode
-  action?: React.ReactNode
+  i18n?: {
+    title?: React.ReactNode
+    content?: React.ReactNode
+    action?: React.ReactNode
+  }
   onSwitchNetwork: () => unknown
 }

--- a/src/components/NetworkAlert/NetworkAlert.types.ts
+++ b/src/components/NetworkAlert/NetworkAlert.types.ts
@@ -1,0 +1,8 @@
+import * as React from 'react'
+
+export type Props = {
+  title?: React.ReactNode
+  content?: React.ReactNode
+  action?: React.ReactNode
+  onSwitchNetwork: () => unknown
+}


### PR DESCRIPTION
This PR adds the NetworkAlert component that will be used as the replacement for the modal that shows the `PartiallySupported` network alert.

<img width="1224" alt="Screenshot 2023-03-03 at 13 31 49" src="https://user-images.githubusercontent.com/1120791/222821427-3873f14b-b963-4a63-abec-a06ff56bb241.png">
<img width="395" alt="Screenshot 2023-03-03 at 13 44 55" src="https://user-images.githubusercontent.com/1120791/222821435-3bbf2552-bb9b-42a5-9c19-6ffdce991b79.png">
