### PR TITLE
fix: bump tile map library version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22227,9 +22227,9 @@
       }
     },
     "react-tile-map": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.3.5.tgz",
-      "integrity": "sha512-tJrHMiDyb+zTGSDrpvMec0kFrCMuIcAHj/Lgzf0OXIBASJAXgXh/DF0aFm2Pp3Ksc1R4u86vcUBRIi8gLrz0cw==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.3.6.tgz",
+      "integrity": "sha512-V69XWdHkfJG8vCppxJWGgj3O2HxELCRWrwN0J0APaYT6TQEsZpB7ciwJf8UWWw35BnZXXsZCGzVgWirhK+1pQQ==",
       "requires": {
         "@types/react-virtualized": "^9.21.2",
         "impetus": "^0.8.8",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-dom": "^17.0.2",
     "react-responsive": "^9.0.0-beta.3",
     "react-semantic-ui-datepickers": "^2.17.2",
-    "react-tile-map": "^0.3.5",
+    "react-tile-map": "^0.3.6",
     "recharts": "^2.3.2",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.0.3"


### PR DESCRIPTION
Bump tile-map library version so that iti includes new event `onCenterChange`