### PR TITLE
fix: error selecting upper bound on bar charts

### DIFF
--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -232,7 +232,7 @@ export const BarChart = ({
 
       handleChange(
         isUpperBoundRange
-          ? [values[0], '']
+          ? [values[0].toString(), '']
           : roundRange(activePayload[0].payload.values),
         null,
         'chart'


### PR DESCRIPTION
When clicking the last bar in the barchart the values in handleChange are being sent as a number without being parse to string causing function `fixedNumber` to fail and the selection never being applied. This pr parses the number to string so `match` function can be called