### PR TITLE
fix: Update react tile map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4501,7 +4501,8 @@
     "@types/prop-types": {
       "version": "15.7.1",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
-      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
+      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==",
+      "dev": true
     },
     "@types/q": {
       "version": "1.5.2",
@@ -4556,42 +4557,11 @@
         "@types/react": "*"
       }
     },
-    "@types/react-virtualized": {
-      "version": "9.21.21",
-      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.21.21.tgz",
-      "integrity": "sha512-Exx6I7p4Qn+BBA1SRyj/UwQlZ0I0Pq7g7uhAp0QQ4JWzZunqEqNBGTmCmMmS/3N9wFgAGWuBD16ap7k8Y14VPA==",
-      "requires": {
-        "@types/prop-types": "*",
-        "@types/react": "^17"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "17.0.53",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.53.tgz",
-          "integrity": "sha512-1yIpQR2zdYu1Z/dc1OxC+MA6GR240u3gcnP4l6mvj/PJiVaqHsQPmWttsvHsfnhfPbU2FuGmo0wSITPygjBmsw==",
-          "requires": {
-            "@types/prop-types": "*",
-            "@types/scheduler": "*",
-            "csstype": "^3.0.2"
-          }
-        },
-        "csstype": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-          "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
-        }
-      }
-    },
     "@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -7223,11 +7193,6 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
-    },
     "cmd-shim": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
@@ -8767,30 +8732,6 @@
       "dev": true,
       "requires": {
         "utila": "~0.4"
-      }
-    },
-    "dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "requires": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.21.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-          "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.11"
-          }
-        },
-        "csstype": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-          "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
-        }
       }
     },
     "dom-serializer": {
@@ -22227,14 +22168,13 @@
       }
     },
     "react-tile-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.3.6.tgz",
-      "integrity": "sha512-V69XWdHkfJG8vCppxJWGgj3O2HxELCRWrwN0J0APaYT6TQEsZpB7ciwJf8UWWw35BnZXXsZCGzVgWirhK+1pQQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.0.tgz",
+      "integrity": "sha512-tJT9LR7WnzjSAn8xHLGGZXpevc1G8NFz8IVICND8PLK/mHtiAVO5MOdOuJWVPYhXc+TpLmOt9mK041hC4Qtc0A==",
       "requires": {
-        "@types/react-virtualized": "^9.21.2",
         "impetus": "^0.8.8",
         "mouse-wheel": "^1.2.0",
-        "react-virtualized": "^9.22.3",
+        "react-virtualized-auto-sizer": "^1.0.9",
         "touch-pinch": "^1.0.1",
         "touch-position": "^2.0.0"
       }
@@ -22260,28 +22200,10 @@
         }
       }
     },
-    "react-virtualized": {
-      "version": "9.22.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
-      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "clsx": "^1.0.4",
-        "dom-helpers": "^5.1.3",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.21.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-          "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.11"
-          }
-        }
-      }
+    "react-virtualized-auto-sizer": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.9.tgz",
+      "integrity": "sha512-O1pYgygCDtFKa9GaKJtX5Ws/QRqxkx2zPlXZqEoRXCMmnNuhoMk5nhXCQqixsc1AcrUzOJwKdzEaDAU9WQ6aJQ=="
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-dom": "^17.0.2",
     "react-responsive": "^9.0.0-beta.3",
     "react-semantic-ui-datepickers": "^2.17.2",
-    "react-tile-map": "^0.3.6",
+    "react-tile-map": "^0.4.0",
     "recharts": "^2.3.2",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.0.3"


### PR DESCRIPTION
This PR updates react-tile map to its latest version which removes `react-virtualized`, supporting react 17 and 18.