### PR TITLE
fix: Use the min and necessary width for the centered toasts container

### DIFF
--- a/src/components/Toasts/Toasts.css
+++ b/src/components/Toasts/Toasts.css
@@ -26,3 +26,8 @@
 .dcl.toasts.bottom.center {
   top: unset;
 }
+
+.dcl.toasts.center {
+  width: min-content;
+  margin: auto;
+}


### PR DESCRIPTION
Related to https://github.com/decentraland/marketplace/issues/1595