### PR TITLE
fix: Define postcss-copy scope

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,7 +5,9 @@ module.exports = {
     'postcss-svg': true,
     'postcss-assets': true,
     'postcss-copy': {
-      dest: 'dist/assets'
-    },
+      'basePath': [`${__dirname}/src`],
+      'preservePath': true,
+      'dest': `${__dirname}/dist/assets`
+    }
   }
 }


### PR DESCRIPTION
This PR encapsulates the `postcss-copy` scope into the module to avoid conflicts with external projects that install this lib and uses `postcss`.