### PR TITLE
fix: Navbar active item font weight

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -138,7 +138,8 @@
   z-index: 1;
 }
 
-.dcl.navbar .ui.menu .item.active {
+.dcl.navbar .ui.menu .item.active,
+.dcl.navbar .ui.menu .item.active .item {
   font-weight: bold;
 }
 


### PR DESCRIPTION
This PR fixes the active navbar item that doesn't show bolded.

<img width="648" alt="image" src="https://github.com/decentraland/ui/assets/3170051/8bbf4664-82d0-4f1f-9d63-bdd8a6ef8960">

<img width="632" alt="image" src="https://github.com/decentraland/ui/assets/3170051/79f55411-68b9-434f-9d97-9cc9f51c13a9">
