### PR TITLE
fix: authorization header and toast

### DIFF
--- a/src/components/AuthorizationModal/AuthorizationModal.css
+++ b/src/components/AuthorizationModal/AuthorizationModal.css
@@ -4,12 +4,12 @@
   max-width: 580px;
 }
 
-.authorization-modal .header {
+.authorization-modal .authorization-header {
   font-weight: 700;
   font-size: 32px;
   line-height: 32px;
+  margin: 0;
   margin-bottom: 48px;
-  margin-top: 0;
 }
 
 .authorization-modal .contract-name {

--- a/src/components/AuthorizationModal/AuthorizationModal.tsx
+++ b/src/components/AuthorizationModal/AuthorizationModal.tsx
@@ -24,7 +24,7 @@ export function AuthorizationModal({
         className="close-button"
         onClick={onClose}
       />
-      <h1 className="header">{header}</h1>
+      <h1 className="authorization-header">{header}</h1>
       <MultiStep currentStep={currentStep} steps={steps} />
     </Modal>
   )

--- a/src/components/Toast/Toast.css
+++ b/src/components/Toast/Toast.css
@@ -8,6 +8,7 @@
   position: relative;
   background-color: var(--toast);
   color: var(--toast-text);
+  width: 100vw;
   z-index: 2147483002; /* Appear over intercom */
 }
 


### PR DESCRIPTION
- This pr fixes authorization header styles by setting a new class different than header that is being used in other parts of the app
- It also adds property width 100vw to the toast so that if possible, it expands to reach the 500px max size


From this: 
<img width="983" alt="image" src="https://github.com/decentraland/ui/assets/11800206/02ae4d82-13f0-47fe-9a4f-53d64b9769c4">

To this:
<img width="1170" alt="image" src="https://github.com/decentraland/ui/assets/11800206/b8f8b6db-5691-47dd-90af-bbd44fdb4f56">
