### PR TITLE
feat: Make field count the text length when maxLength is set

### DIFF
--- a/src/components/Field/Field.css
+++ b/src/components/Field/Field.css
@@ -15,7 +15,11 @@
 
 .dcl.field .ui.header.sub {
   display: flex;
-  justify-content: space-between;
+  justify-content: end;
+}
+
+.dcl.field .ui.header.sub .maxLength {
+  margin-left: auto;
 }
 
 .dcl.field .ui.input input,

--- a/src/components/Field/Field.css
+++ b/src/components/Field/Field.css
@@ -15,7 +15,6 @@
 
 .dcl.field .ui.header.sub {
   display: flex;
-  justify-content: end;
 }
 
 .dcl.field .ui.header.sub .maxLength {

--- a/src/components/Field/Field.css
+++ b/src/components/Field/Field.css
@@ -13,6 +13,11 @@
   width: 100%;
 }
 
+.dcl.field .ui.header.sub {
+  display: flex;
+  justify-content: space-between;
+}
+
 .dcl.field .ui.input input,
 .ui.form .dcl.field .ui.input input {
   padding: 0px;

--- a/src/components/Field/Field.stories.tsx
+++ b/src/components/Field/Field.stories.tsx
@@ -122,6 +122,9 @@ storiesOf('Field', module)
       />
     </Form>
   ))
-  .add('With maxLength', () => (
-    <Field label="Label" maxLength={20} value="A value" />
+  .add('With maxLength and no label', () => (
+    <Field maxLength={20} value="A value" />
+  ))
+  .add('With maxLength and label', () => (
+    <Field label="A label" maxLength={20} value="A value" />
   ))

--- a/src/components/Field/Field.stories.tsx
+++ b/src/components/Field/Field.stories.tsx
@@ -122,3 +122,6 @@ storiesOf('Field', module)
       />
     </Form>
   ))
+  .add('With maxLength', () => (
+    <Field label="Label" maxLength={20} value="A value" />
+  ))

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -31,6 +31,8 @@ export type FieldProps = InputProps & {
   fitContent?: boolean
   /** Boolean flag to determine if datepicker can be cleared, default on true */
   isClearable?: boolean
+  /** Defines the maximum number of characters the user can enter into the input */
+  maxLength?: number
 }
 
 export class Field extends React.PureComponent<FieldProps> {
@@ -90,6 +92,7 @@ export class Field extends React.PureComponent<FieldProps> {
       fitContent,
       isClearable = true,
       id,
+      maxLength,
       ...rest
     } = this.props
 
@@ -114,6 +117,11 @@ export class Field extends React.PureComponent<FieldProps> {
         {label ? (
           <Header sub>
             <label htmlFor={id}>{label}</label>
+            {maxLength !== undefined ? (
+              <span>
+                {value.length}/{maxLength}
+              </span>
+            ) : null}
           </Header>
         ) : null}
         {type === DATE_TYPE ? (
@@ -138,6 +146,7 @@ export class Field extends React.PureComponent<FieldProps> {
             icon={icon}
             loading={loading && !isAddress}
             disabled={disabled}
+            maxLength={maxLength}
             {...rest}
           />
         )}

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -7,6 +7,7 @@ import Input, {
   InputProps
 } from 'semantic-ui-react/dist/commonjs/elements/Input/Input'
 import classnames from 'classnames'
+import { getInputValueLength } from '../../lib/input'
 import { Blockie } from '../Blockie/Blockie'
 import { Button } from '../Button/Button'
 import { Header } from '../Header/Header'
@@ -119,7 +120,7 @@ export class Field extends React.PureComponent<FieldProps> {
             {label ? <label htmlFor={id}>{label}</label> : null}
             {maxLength !== undefined ? (
               <span className="maxLength">
-                {value.length}/{maxLength}
+                {getInputValueLength(value)}/{maxLength}
               </span>
             ) : null}
           </Header>

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -114,11 +114,11 @@ export class Field extends React.PureComponent<FieldProps> {
 
     return (
       <div className={classes}>
-        {label ? (
+        {label || maxLength !== undefined ? (
           <Header sub>
-            <label htmlFor={id}>{label}</label>
+            {label ? <label htmlFor={id}>{label}</label> : null}
             {maxLength !== undefined ? (
-              <span>
+              <span className="maxLength">
                 {value.length}/{maxLength}
               </span>
             ) : null}

--- a/src/lib/input.ts
+++ b/src/lib/input.ts
@@ -1,0 +1,6 @@
+export function getInputValueLength(value: string | number | undefined | null) {
+  if (value === undefined || value === null) {
+    return 0
+  }
+  return typeof value === 'string' ? value.length : value.toString().length
+}


### PR DESCRIPTION
When `maxLength` is set, add the length count and its max length next to its label.

![Screenshot 2023-05-24 at 12 08 08](https://github.com/decentraland/ui/assets/1120791/2863be6e-0710-4960-af7d-6595efadcbe0)
