### PR TITLE
feat: Add max length count for the TextArea component

### DIFF
--- a/src/components/TextAreaField/TextAreaField.css
+++ b/src/components/TextAreaField/TextAreaField.css
@@ -3,12 +3,19 @@
   flex-direction: column;
 }
 
-.dcl.text-area > .label {
+.dcl.text-area > .title {
   margin-bottom: 8px;
-  color: #736e7d;
+  font-size: 13px;
   font-family: var(--font-family);
   color: var(--secondary-text);
-  font-size: 13px;
+  display: flex;
+}
+
+.dcl.text-area > .title > .maxLength {
+  margin-left: auto;
+}
+
+.dcl.text-area > .title > label {
   text-transform: uppercase;
 }
 

--- a/src/components/TextAreaField/TextAreaField.stories.tsx
+++ b/src/components/TextAreaField/TextAreaField.stories.tsx
@@ -25,6 +25,18 @@ storiesOf('TextArea', module)
       cols="50"
     />
   ))
+  .add('Text area without label and max length', () => (
+    <TextAreaField maxLength={300} value={textAreaValue} rows="10" cols="50" />
+  ))
+  .add('Text area with label and max length', () => (
+    <TextAreaField
+      maxLength={300}
+      label="Description"
+      value={textAreaValue}
+      rows="10"
+      cols="50"
+    />
+  ))
   .add('Text area with label in form', () => (
     <Form>
       <TextAreaField

--- a/src/components/TextAreaField/TextAreaField.tsx
+++ b/src/components/TextAreaField/TextAreaField.tsx
@@ -4,7 +4,17 @@ import TextArea, {
 } from 'semantic-ui-react/dist/commonjs/addons/TextArea/TextArea'
 import './TextAreaField.css'
 
-export type TextAreaFieldProps = TextAreaProps & { label?: string }
+export type TextAreaFieldProps = TextAreaProps & {
+  label?: string
+  maxLength?: number
+}
+
+function getValueLength(value: TextAreaFieldProps['value']) {
+  if (value === undefined) {
+    return 0
+  }
+  return typeof value === 'string' ? value.length : value.toString().length
+}
 
 export const TextAreaField = (props: TextAreaFieldProps): JSX.Element => {
   const textAreaProps = { ...props }
@@ -12,7 +22,17 @@ export const TextAreaField = (props: TextAreaFieldProps): JSX.Element => {
 
   return (
     <div className="dcl text-area">
-      {props.label && <div className="label">{props.label}</div>}
+      {props.label || props.maxLength !== undefined ? (
+        <div className="title">
+          {props.label ? <label>{props.label}</label> : null}
+          {props.maxLength ? (
+            <span className="maxLength">
+              {getValueLength(props.value)}/{props.maxLength}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
       <TextArea {...textAreaProps} />
     </div>
   )

--- a/src/components/TextAreaField/TextAreaField.tsx
+++ b/src/components/TextAreaField/TextAreaField.tsx
@@ -2,18 +2,12 @@ import * as React from 'react'
 import TextArea, {
   TextAreaProps
 } from 'semantic-ui-react/dist/commonjs/addons/TextArea/TextArea'
+import { getInputValueLength } from '../../lib/input'
 import './TextAreaField.css'
 
 export type TextAreaFieldProps = TextAreaProps & {
   label?: string
   maxLength?: number
-}
-
-function getValueLength(value: TextAreaFieldProps['value']) {
-  if (value === undefined) {
-    return 0
-  }
-  return typeof value === 'string' ? value.length : value.toString().length
 }
 
 export const TextAreaField = (props: TextAreaFieldProps): JSX.Element => {
@@ -27,7 +21,7 @@ export const TextAreaField = (props: TextAreaFieldProps): JSX.Element => {
           {props.label ? <label>{props.label}</label> : null}
           {props.maxLength ? (
             <span className="maxLength">
-              {getValueLength(props.value)}/{props.maxLength}
+              {getInputValueLength(props.value)}/{props.maxLength}
             </span>
           ) : null}
         </div>


### PR DESCRIPTION
This PR adds the max length count on the top right of the TextArea component when the prop is set.

![Screenshot 2023-05-24 at 14 13 18](https://github.com/decentraland/ui/assets/1120791/eab50b0d-46d0-484b-894c-4ffb8a95403d)
![Screenshot 2023-05-24 at 14 13 12](https://github.com/decentraland/ui/assets/1120791/a69216ec-2d92-4cd3-aba5-9b40bc6683ae)
![Screenshot 2023-05-24 at 14 13 04](https://github.com/decentraland/ui/assets/1120791/b31c4f55-8720-48ea-af26-17c97f01770c)
