### PR TITLE
fix: Add blankspace to TextAreaField message

### DIFF
--- a/src/components/TextAreaField/TextAreaField.tsx
+++ b/src/components/TextAreaField/TextAreaField.tsx
@@ -67,7 +67,7 @@ export const TextAreaField = (props: TextAreaFieldProps): JSX.Element => {
       ) : null}
 
       <TextArea {...restOfProps} />
-      <p className="message">{renderMessage(props)}</p>
+      <p className="message">{renderMessage(props)}&nbsp;</p>
     </div>
   )
 }


### PR DESCRIPTION
This PR adds a missing blank space in the TextAreaField component that sets a space for the message to exist.