### PR TITLE
feat: Add worlds option to the navbar

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -46,6 +46,7 @@ export type NavbarI18N = {
       scenes: React.ReactNode
       land: React.ReactNode
       names: React.ReactNode
+      worlds: React.ReactNode
     }
   }
   account: {
@@ -137,7 +138,8 @@ export class Navbar extends React.PureComponent<NavbarProps, NavbarState> {
           collections: 'Collections',
           scenes: 'Scenes',
           land: 'Land',
-          names: 'Names'
+          names: 'Names',
+          worlds: 'Worlds'
         }
       },
       account: {
@@ -304,6 +306,14 @@ export class Navbar extends React.PureComponent<NavbarProps, NavbarState> {
             }
           >
             {i18n.menu.builder.names}
+          </Menu.Item>
+          <Menu.Item
+            href="https://builder.decentraland.org/worlds"
+            onMouseDown={(e: React.MouseEvent) =>
+              this.handleClickMenuOption(e, `${NavbarPages.BUILDER}_worlds`)
+            }
+          >
+            {i18n.menu.builder.worlds}
           </Menu.Item>
         </Menu>
       </Menu.Item>


### PR DESCRIPTION
This PR adds the `worlds` option to the navbar.

<img width="631" alt="image" src="https://github.com/decentraland/ui/assets/3170051/060f5a29-baa6-457f-9fb0-15f5ef1e0066">
