### PR TITLE
feat: Extend select field accepting elements as labels

### DIFF
--- a/src/components/SelectField/SelectField.tsx
+++ b/src/components/SelectField/SelectField.tsx
@@ -4,7 +4,7 @@ import { Header } from '../Header/Header'
 import './SelectField.css'
 
 export type SelectFieldProps = DropdownProps & {
-  label?: string
+  label?: string | JSX.Element
   error?: boolean
   message?: string
   header?: JSX.Element


### PR DESCRIPTION
Needed to render the header of the fields in the create item flow as follows:
<img width="688" alt="image" src="https://github.com/decentraland/ui/assets/31735779/79ed1781-e164-4802-b2fb-c5907480aa52">
