### PR TITLE
fix: Remove flagged user menu

### DIFF
--- a/src/components/UserMenu/UserMenu.tsx
+++ b/src/components/UserMenu/UserMenu.tsx
@@ -115,18 +115,6 @@ export class UserMenu extends React.Component<UserMenuProps, UserMenuState> {
     )
   }
 
-  renderOldMenuOptions() {
-    const { i18n } = this.props
-    return (
-      <a href="https://account.decentraland.org">
-        <li>
-          <Icon name="user" />
-          {i18n.account}
-        </li>
-      </a>
-    )
-  }
-
   renderNewMenuOptions() {
     const { i18n } = this.props
     return (
@@ -155,7 +143,6 @@ export class UserMenu extends React.Component<UserMenuProps, UserMenuState> {
       isSigningIn,
       isActivity,
       hasActivity,
-      newMenu,
       onSignOut,
       onSignIn,
       onClickProfile,
@@ -211,10 +198,18 @@ export class UserMenu extends React.Component<UserMenuProps, UserMenuState> {
                     </div>
                   </div>
                   <ul className="actions">
-                    {/* TODO: Remove this prop after profile dApps release and leave only the new menu */}
-                    {newMenu
-                      ? this.renderNewMenuOptions()
-                      : this.renderOldMenuOptions()}
+                    <a href="https://profile.decentraland.org">
+                      <li>
+                        <Icon name="user" />
+                        {i18n.profile}
+                      </li>
+                    </a>
+                    <a href="https://account.decentraland.org">
+                      <li>
+                        <WalletIcon />
+                        {i18n.wallet}
+                      </li>
+                    </a>
                     {menuItems}
                     {onClickSettings ? (
                       <li onClick={onClickSettings}>


### PR DESCRIPTION
This PR removes the flag that rendered one of two menus. This is used in the dApps with the profile site FF.