### PR TITLE
fix: Popup center styles

### DIFF
--- a/src/components/Popup/Popup.css
+++ b/src/components/Popup/Popup.css
@@ -21,16 +21,24 @@
 .ui.bottom.center.popup:before,
 .ui.bottom.left.popup:before,
 .ui.bottom.right.popup:before,
+.ui.left.center.popup:before,
+.ui.right.center.popup:before,
 .ui.inverted.bottom.center.popup:before,
 .ui.inverted.bottom.left.popup:before,
-.ui.inverted.bottom.right.popup:before {
+.ui.inverted.bottom.right.popup:before,
+.ui.inverted.left.center.popup:before,
+.ui.inverted.right.center.popup:before {
   box-shadow: none;
 }
 
 .ui.bottom.popup:before,
 .ui.top.popup:before,
+.ui.left.center.popup:before,
+.ui.right.center.popup:before,
 .ui.inverted.bottom.popup:before,
-.ui.inverted.top.popup:before {
+.ui.inverted.top.popup:before,
+.ui.inverted.left.center.popup:before,
+.ui.inverted.right.center.popup:before {
   background-color: var(--popup);
 }
 
@@ -70,5 +78,19 @@
 .ui.inverted.bottom.right.popup:before {
   top: -6px;
   border-top: var(--popup-outline);
+  border-left: var(--popup-outline);
+}
+
+.ui.center.left.popup:before,
+.ui.inverted.center.left.popup:before {
+  right: -5.5px;
+  border-top: var(--popup-outline);
+  border-right: var(--popup-outline);
+}
+
+.ui.center.right.popup:before,
+.ui.inverted.center.right.popup:before {
+  left: -5.5px;
+  border-bottom: var(--popup-outline);
   border-left: var(--popup-outline);
 }

--- a/src/components/Popup/Popup.stories.tsx
+++ b/src/components/Popup/Popup.stories.tsx
@@ -73,6 +73,20 @@ storiesOf('Popup', module)
           on="hover"
         />
       </div>
+      <div className="Popup-story-row">
+        <Popup
+          content="Hello"
+          position="left center"
+          trigger={<b>Left Center</b>}
+          on="hover"
+        />
+        <Popup
+          content="Hello"
+          position="right center"
+          trigger={<b>Right Center</b>}
+          on="hover"
+        />
+      </div>
     </>
   ))
   .add('Closable', () => (


### PR DESCRIPTION
This PR fixes the popup center styles.

Before:
* <img width="182" alt="image" src="https://github.com/decentraland/ui/assets/3170051/6449b558-7415-4bcd-b4d5-280f10670bd2">
* <img width="180" alt="image" src="https://github.com/decentraland/ui/assets/3170051/df7961a7-8014-4cd5-8683-6c39efaaeae3">

After:
* <img width="184" alt="image" src="https://github.com/decentraland/ui/assets/3170051/6b9e1e98-2bd1-4aa7-875f-c3e3a6b6e35d">
* <img width="182" alt="image" src="https://github.com/decentraland/ui/assets/3170051/bddb9b50-b084-487f-9450-bb8571e1372f">

