### PR TITLE
feat: Add Radio Options component

### DIFF
--- a/src/components/Radio/Radio.css
+++ b/src/components/Radio/Radio.css
@@ -120,3 +120,21 @@
 .ui.toggle.checkbox input[type='radio'].hidden:focus + label:before {
   outline: 1px solid white;
 }
+
+/* Rounded style */
+.ui.radio.checkbox input[type='radio'].hidden ~ label:before,
+.ui.radio.checkbox input[type='radio'].hidden:focus ~ label:before {
+  border: 2px solid #736e7d;
+  background-color: transparent;
+}
+
+.ui.radio.checkbox:hover input[type='radio'].hidden ~ label:before {
+  background-color: var(--primary);
+}
+
+.ui.radio.checkbox.checked input[type='radio'].hidden + label:after {
+  background-image: none;
+  width: 23px;
+  height: 23px;
+  border: 3px solid var(--secondary);
+}

--- a/src/components/RadioOptions/RadioOptions.css
+++ b/src/components/RadioOptions/RadioOptions.css
@@ -1,0 +1,18 @@
+.dui-radio-options {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+.dui-radio-options .ui.radio.checkbox {
+  margin-top: 13px;
+  margin-bottom: 13px;
+  display: flex;
+  align-items: center;
+}
+
+.dui-radio-options .ui.checkbox label {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  gap: 6px;
+}

--- a/src/components/RadioOptions/RadioOptions.spec.tsx
+++ b/src/components/RadioOptions/RadioOptions.spec.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import { RadioOptions } from './RadioOptions'
+import { RadioOptionsProps } from './RadioOptions.types'
+
+function renderRadioOptions(props: Partial<RadioOptionsProps<string>> = {}) {
+  return render(
+    <RadioOptions
+      value={undefined}
+      options={[]}
+      onChange={jest.fn()}
+      {...props}
+    />
+  )
+}
+
+let renderedComponent: ReturnType<typeof renderRadioOptions>
+let options: RadioOptionsProps<string>['options']
+
+describe('when rendering the component', () => {
+  beforeEach(() => {
+    options = [
+      { name: 'First option', value: 'first_option' },
+      { name: 'Second option', value: 'second_option' },
+      { name: 'Third option', value: 'third_option', info: 'Some info!' }
+    ]
+    renderedComponent = renderRadioOptions({ options })
+  })
+
+  it('should render a radio button for each option', () => {
+    const { getByText } = renderedComponent
+
+    options.forEach((option) => {
+      const radio = getByText(option.name)
+      expect(radio).toBeInTheDocument()
+      if (option.info) {
+        expect(
+          radio.querySelector('.dui-info-tooltip__trigger')
+        ).toBeInTheDocument()
+      }
+    })
+  })
+})
+
+describe('when clicking on an option', () => {
+  let value: string
+  let onChange: jest.Mock
+
+  beforeEach(() => {
+    onChange = jest.fn()
+    options = [
+      { name: 'First option', value: 'first_option' },
+      { name: 'Second option', value: 'second_option' },
+      { name: 'Third option', value: 'third_option', info: 'Some info!' }
+    ]
+  })
+
+  describe('and the option is already selected', () => {
+    beforeEach(() => {
+      value = options[0].value
+      renderedComponent = renderRadioOptions({ options, value, onChange })
+    })
+
+    it('should not call the onChange callback', () => {
+      const { getByText } = renderedComponent
+
+      const radio = getByText(options[0].name).previousSibling
+      fireEvent.click(radio)
+
+      expect(onChange).not.toHaveBeenCalledWith(value)
+    })
+  })
+
+  describe('and the option is not selected', () => {
+    beforeEach(() => {
+      value = options[1].value
+      renderedComponent = renderRadioOptions({ options, value, onChange })
+    })
+
+    it('should call the onChange callback with the new value', () => {
+      const { getByText } = renderedComponent
+
+      const radio = getByText(options[0].name).previousSibling
+      fireEvent.click(radio)
+
+      expect(onChange).toHaveBeenCalledWith(options[0].value)
+    })
+  })
+})

--- a/src/components/RadioOptions/RadioOptions.spec.tsx
+++ b/src/components/RadioOptions/RadioOptions.spec.tsx
@@ -65,8 +65,8 @@ describe('when clicking on an option', () => {
     it('should not call the onChange callback', () => {
       const { getByText } = renderedComponent
 
-      const radio = getByText(options[0].name).previousSibling
-      userEvent.click(radio as Element)
+      const radio = getByText(options[0].name)
+      userEvent.click(radio)
 
       expect(onChange).not.toHaveBeenCalledWith(value)
     })
@@ -81,8 +81,8 @@ describe('when clicking on an option', () => {
     it('should call the onChange callback with the new value', () => {
       const { getByText } = renderedComponent
 
-      const radio = getByText(options[0].name).previousSibling
-      userEvent.click(radio as Element)
+      const radio = getByText(options[0].name)
+      userEvent.click(radio)
 
       expect(onChange).toHaveBeenCalledWith(options[0].value)
     })

--- a/src/components/RadioOptions/RadioOptions.spec.tsx
+++ b/src/components/RadioOptions/RadioOptions.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { RadioOptions } from './RadioOptions'
 import { RadioOptionsProps } from './RadioOptions.types'
 
@@ -65,7 +66,7 @@ describe('when clicking on an option', () => {
       const { getByText } = renderedComponent
 
       const radio = getByText(options[0].name).previousSibling
-      fireEvent.click(radio)
+      userEvent.click(radio as Element)
 
       expect(onChange).not.toHaveBeenCalledWith(value)
     })
@@ -81,7 +82,7 @@ describe('when clicking on an option', () => {
       const { getByText } = renderedComponent
 
       const radio = getByText(options[0].name).previousSibling
-      fireEvent.click(radio)
+      userEvent.click(radio as Element)
 
       expect(onChange).toHaveBeenCalledWith(options[0].value)
     })

--- a/src/components/RadioOptions/RadioOptions.stories.css
+++ b/src/components/RadioOptions/RadioOptions.stories.css
@@ -1,0 +1,7 @@
+.radio-options-story {
+  padding: 30px;
+  border-radius: 15px;
+  background-color: #242129;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/RadioOptions/RadioOptions.stories.tsx
+++ b/src/components/RadioOptions/RadioOptions.stories.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react'
+import { storiesOf } from '@storybook/react'
+import { RadioOptions } from './RadioOptions'
+import './RadioOptions.stories.css'
+
+storiesOf('RadioOptions', module).add('Select options', () => {
+  const options = [
+    { name: 'First option', info: 'This is the first option', value: 'first' },
+    {
+      name: 'Second option',
+      info: 'This is the second option',
+      value: 'second'
+    },
+    { name: 'Third option', value: 'third' }
+  ]
+  const [value, onValueChange] = useState(undefined)
+
+  return (
+    <div className="radio-options-story">
+      <RadioOptions value={value} options={options} onChange={onValueChange} />
+    </div>
+  )
+})

--- a/src/components/RadioOptions/RadioOptions.tsx
+++ b/src/components/RadioOptions/RadioOptions.tsx
@@ -1,0 +1,38 @@
+import React, { useCallback } from 'react'
+import classNames from 'classnames'
+import { Radio } from '../Radio/Radio'
+import { InfoTooltip } from '../InfoTooltip'
+import { RadioOptionsProps } from './RadioOptions.types'
+import './RadioOptions.css'
+
+export const RadioOptions = <T extends string | number | undefined>(
+  props: RadioOptionsProps<T>
+) => {
+  const { onChange, value, options, className } = props
+
+  const handleChange = useCallback(
+    (_evt, { value }) => {
+      return onChange(value)
+    },
+    [onChange]
+  )
+  return (
+    <div className={classNames('dui-radio-options', className)}>
+      {options.map((option) => (
+        <Radio
+          type="radio"
+          key={option.value}
+          onChange={handleChange}
+          label={
+            <label className="dui-radio-options__label">
+              {option.name}
+              {option.info ? <InfoTooltip content={option.info} /> : null}
+            </label>
+          }
+          value={option.value}
+          checked={option.value === value}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/RadioOptions/RadioOptions.types.ts
+++ b/src/components/RadioOptions/RadioOptions.types.ts
@@ -1,0 +1,6 @@
+export type RadioOptionsProps<T extends string | number | undefined> = {
+  value: T
+  options: { name: string; info?: string; value: T }[]
+  onChange: (options: T) => unknown
+  className?: string
+}

--- a/src/components/RadioOptions/index.ts
+++ b/src/components/RadioOptions/index.ts
@@ -1,0 +1,1 @@
+export * from './RadioOptions'


### PR DESCRIPTION
This PR adds the `RadioOptions` component which generates a radio group with radio buttons given a set of options.
![Screenshot 2023-09-27 at 15 55 41](https://github.com/decentraland/ui/assets/1120791/585f9820-2dc0-449c-99f3-eca0ecded7a8)
It also changes the `Radio` styles for the new ones that are already working in the Marketplace.
![Screenshot 2023-09-27 at 15 56 01](https://github.com/decentraland/ui/assets/1120791/5620bc52-5246-4e86-994a-2d1352c2951a)
