### PR TITLE
fix: Small side menu changes

### DIFF
--- a/src/components/SideMenu/SideMenu.css
+++ b/src/components/SideMenu/SideMenu.css
@@ -1,6 +1,4 @@
 .dui-side-menu {
-  overflow: hidden;
-  padding-bottom: 21px;
   list-style-type: none;
   margin-block-start: 0px;
   padding-inline-start: 0px;


### PR DESCRIPTION
This PR removes the `overflow` property which was preventing the component from growing and the `padding-bottom` which is not necessary.