### PR TITLE
fix: Remove some CategoryFilter's styles

### DIFF
--- a/src/components/CategoryFilter/CategoryFilter.css
+++ b/src/components/CategoryFilter/CategoryFilter.css
@@ -1,8 +1,6 @@
 .dui-category-filter.dcl.box {
   background-color: var(--card);
   border-radius: 10px;
-  overflow: hidden;
-  padding-bottom: 21px;
   border: none;
   padding: 0px;
 }


### PR DESCRIPTION
This PR removes some CSS properties that aren't needed anymore.