### PR TITLE
fix: Add hashtag on profile names

### DIFF
--- a/src/components/Profile/Profile.stories.tsx
+++ b/src/components/Profile/Profile.stories.tsx
@@ -16,6 +16,19 @@ storiesOf('Profile', module)
       <Profile address="0xdeadbeef" avatar={avatar} />
     </>
   ))
+  .add('Avatar without name', () => (
+    <>
+      <Profile address="0xdeadbeef" avatar={{ ...avatar, name: null }} />
+    </>
+  ))
+  .add('Avatar with an unclaimed name', () => (
+    <>
+      <Profile
+        address="0xdeadbeef"
+        avatar={{ ...avatar, hasClaimedName: false }}
+      />
+    </>
+  ))
   .add('Image only', () => (
     <>
       <Profile address="0xdeadbeef" avatar={avatar} imageOnly />

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -16,6 +16,9 @@ type Props<T extends React.ElementType> = {
   sliceAddressBy?: number
   size?: 'normal' | 'large' | 'huge' | 'massive'
   isDecentraland?: boolean
+  i18n?: {
+    defaultName: string
+  }
   as?: T
 }
 
@@ -40,7 +43,19 @@ export const Profile = function <T extends React.ElementType>(
   } = props
 
   const sliceLimit = Math.max(Math.min(sliceAddressBy, 42), 6)
-  const name = (avatar && avatar.name) || address.slice(0, sliceLimit)
+  const name = React.useMemo(() => {
+    if (!avatar || !avatar.name) {
+      return address.slice(0, sliceLimit)
+    }
+
+    if (avatar.hasClaimedName) {
+      return avatar.name
+    }
+
+    const lastPart = `#${avatar?.userId.slice(-4)}`
+    return avatar.name.endsWith(lastPart) ? avatar.name : avatar.name + lastPart
+  }, [avatar, address, sliceLimit])
+
   const Wrapper = as
 
   if (isDecentraland) {


### PR DESCRIPTION
This PR adds the missing hashtag that was removed in a breaking change in the way the profiles are saved.
<img width="129" alt="Screenshot 2023-10-16 at 10 09 19" src="https://github.com/decentraland/ui/assets/1120791/edae025e-3c58-4425-8b1d-565019100ba7">
