### PR TITLE
fix: Capitalize mobile menu

### DIFF
--- a/src/components/Navbar/MenuItem/MenuItem.css
+++ b/src/components/Navbar/MenuItem/MenuItem.css
@@ -15,6 +15,7 @@
 @media (max-width: 991px) {
   .item.dui-menu-item.mobile {
     cursor: pointer;
+    text-transform: capitalize;
     padding: 40px 0 23.66px;
     display: flex;
     align-items: center;


### PR DESCRIPTION
This PR capitalizes the texts in the mobile menu:
![Screenshot 2024-01-24 at 10 25 12](https://github.com/decentraland/ui/assets/1120791/5b192153-face-4598-bbdb-454d12ebaacd)
