### PR TITLE
feat: update tabs idle and hover styles

### DIFF
--- a/src/components/Tabs/Tabs.css
+++ b/src/components/Tabs/Tabs.css
@@ -25,9 +25,17 @@
   line-height: 26px;
   letter-spacing: -0.2px;
   cursor: pointer;
+  color: var(--navbar-item-text-enabled);
+  font-weight: 400;
 }
+
 .dcl.tab.active {
+  color: var(--text);
   font-weight: 600;
+}
+
+.dcl.tab:hover {
+  color: var(--text);
 }
 
 .dcl.tab .active-bar {


### PR DESCRIPTION
Now styles are similar to new navbar.

Closes decentraland/governance#1355

<img width="344" alt="image" src="https://github.com/decentraland/ui/assets/8242162/e27f94a7-56a5-4636-89a4-8234d7ef4e1f">

<img width="312" alt="image" src="https://github.com/decentraland/ui/assets/8242162/acc35303-dead-43ba-90e7-8c0a071d27c7">
