### PR TITLE
fix: Show Icon Badge pointer if clickable

### DIFF
--- a/src/components/IconBadge/IconBadge.css
+++ b/src/components/IconBadge/IconBadge.css
@@ -4,9 +4,12 @@
   text-transform: uppercase;
   padding: 2px 8px;
   border-radius: 5px;
-  cursor: pointer;
   background-color: #37333d;
   min-height: 24px;
+}
+
+.dui-icon-badge.clickable {
+  cursor: pointer;
 }
 
 .dui-icon-badge .text {

--- a/src/components/IconBadge/IconBadge.tsx
+++ b/src/components/IconBadge/IconBadge.tsx
@@ -25,7 +25,14 @@ export const IconBadge = ({
   )
 
   return (
-    <span className={classNames('dui-icon-badge', className)} onClick={onClick}>
+    <span
+      className={classNames(
+        'dui-icon-badge',
+        className,
+        onClick && 'clickable'
+      )}
+      onClick={onClick}
+    >
       {childrenInt}
     </span>
   )


### PR DESCRIPTION
This PR makes the IconBadge component show a pointer only if it has the onClick method prop set.