### PR TITLE
feat: Add disconnecting loader

### DIFF
--- a/src/components/UserMenu/UserMenu.css
+++ b/src/components/UserMenu/UserMenu.css
@@ -5,6 +5,12 @@
   outline: none;
 }
 
+.dcl .user-menu-loader {
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
+
 .dcl .user-menu__jump-in {
   padding: 14px 32px;
   margin-left: 24px;

--- a/src/components/UserMenu/UserMenu.stories.css
+++ b/src/components/UserMenu/UserMenu.stories.css
@@ -1,14 +1,16 @@
 .usermenu-story-container {
-  position: absolute;
-  top: 100px;
-  right: 100px;
-  height: 100vh;
-  width: 100%;
+  width: 500px;
+  padding: 10px;
+  border: 2px solid #7c7777;
+  border-radius: 5px;
 }
 
 @media (max-width: 991px) {
   .usermenu-story-container {
+    position: absolute;
+    height: 400px;
+    width: 100vw;
+    top: 100px;
     left: 0;
-    right: 0;
   }
 }

--- a/src/components/UserMenu/UserMenu.stories.tsx
+++ b/src/components/UserMenu/UserMenu.stories.tsx
@@ -23,6 +23,16 @@ storiesOf('UserMenu', module)
       <UserMenu i18n={i18n} isSignedIn avatar={avatar} />
     </div>
   ))
+  .add('Signing in', () => (
+    <div className="usermenu-story-container">
+      <UserMenu i18n={i18n} isSigningIn />
+    </div>
+  ))
+  .add('Disconnecting', () => (
+    <div className="usermenu-story-container">
+      <UserMenu i18n={i18n} isDisconnecting />
+    </div>
+  ))
   .add('Guest', () => (
     <div className="usermenu-story-container">
       <UserMenu

--- a/src/components/UserMenu/UserMenu.tsx
+++ b/src/components/UserMenu/UserMenu.tsx
@@ -8,6 +8,7 @@ import { i18n as i18nUserMenu } from './UserMenu.i18n'
 import { UserMenuProps, UserMenuEventId } from './UserMenu.types'
 import { Button } from '../Button/Button'
 import { Column } from '../Column/Column'
+import { Loader } from '../Loader/Loader'
 import { config } from '../../config'
 import { Row } from '../Row/Row'
 
@@ -18,6 +19,7 @@ export const UserMenu = React.memo((props: UserMenuProps) => {
   const {
     isSignedIn,
     isSigningIn,
+    isDisconnecting,
     manaBalances,
     i18n = i18nUserMenu,
     onClickSignIn,
@@ -132,34 +134,48 @@ export const UserMenu = React.memo((props: UserMenuProps) => {
           onBlur={handleClose}
           tabIndex={0}
         >
-          {isSignedIn && (
-            <UserMenuSignedIn
-              {...signInProps}
-              manaBalances={manaBalances}
-              trackingId={trackingId}
-              isOpen={isOpen}
-              i18n={i18n}
-              onClickToggle={handleToggle}
-              onClickClose={handleClose}
-              onClickUserMenuItem={onClickUserMenuItem}
-              onClickBalance={handleClickBalance}
-            />
+          {isDisconnecting ? (
+            <div className="dcl user-menu-loader">
+              <Loader inline active size="medium" />
+            </div>
+          ) : (
+            <>
+              {isSignedIn && (
+                <UserMenuSignedIn
+                  {...signInProps}
+                  manaBalances={manaBalances}
+                  trackingId={trackingId}
+                  isOpen={isOpen}
+                  i18n={i18n}
+                  onClickToggle={handleToggle}
+                  onClickClose={handleClose}
+                  onClickUserMenuItem={onClickUserMenuItem}
+                  onClickBalance={handleClickBalance}
+                />
+              )}
+              {!isSignedIn ? (
+                <Button
+                  inverted
+                  disabled={isSigningIn}
+                  loading={isSigningIn}
+                  onClick={handleClickSignIn}
+                >
+                  {i18n.signIn}
+                </Button>
+              ) : null}
+              {isSignedIn && (
+                <Button
+                  className="user-menu__jump-in"
+                  primary
+                  onClick={handleClickJumpIn}
+                  as={'a'}
+                  href={config.get('EXPLORER_URL')}
+                >
+                  {i18n.jumpIn}
+                </Button>
+              )}
+            </>
           )}
-          {!isSignedIn && (
-            <Button inverted disabled={isSigningIn} onClick={handleClickSignIn}>
-              {i18n.signIn}
-            </Button>
-          )}
-          <Button
-            className="user-menu__jump-in"
-            primary
-            disabled={isSigningIn}
-            onClick={handleClickJumpIn}
-            as={'a'}
-            href={config.get('EXPLORER_URL')}
-          >
-            {i18n.jumpIn}
-          </Button>
         </div>
       </Row>
     </Column>

--- a/src/components/UserMenu/UserMenu.types.ts
+++ b/src/components/UserMenu/UserMenu.types.ts
@@ -7,6 +7,7 @@ export type UserMenuProps = Omit<
 > & {
   isSignedIn?: boolean
   isSigningIn?: boolean
+  isDisconnecting?: boolean
   isActivity?: boolean
   i18n?: UserMenuI18N
   onClickSignIn?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void


### PR DESCRIPTION
This PR does the following:
- Adds a disconnecting loader when the user is disconnecting their wallet.
- Makes the jump in button visible only when the user is logged in.