### PR TITLE
fix: upgrade @dcl/ui-env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dcl/schemas": "^11.9.0",
-        "@dcl/ui-env": "^1.4.0",
+        "@dcl/ui-env": "^1.5.1",
         "balloon-css": "^0.5.0",
         "classnames": "^2.3.2",
         "dayjs": "^1.11.10",
@@ -2126,9 +2126,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/ui-env": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@dcl/ui-env/-/ui-env-1.4.0.tgz",
-      "integrity": "sha512-Eog+aXVSSZGtbMG5jzwx+r1KfBazie2HwTF9qDwOd8WBukEAwDc/UxFCJzoGt9TEbu4l0/SFhvSp5lDr/S1wfg=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@dcl/ui-env/-/ui-env-1.5.1.tgz",
+      "integrity": "sha512-03cPMH3wrNK5bdDEoidnXIr0ZpGPe0ly8ObDNwik6PjXF+g2YBAbo5/jDUN0panddL6N6YnCJROP8NkZl/ThnQ=="
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -49202,9 +49202,9 @@
       }
     },
     "@dcl/ui-env": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@dcl/ui-env/-/ui-env-1.4.0.tgz",
-      "integrity": "sha512-Eog+aXVSSZGtbMG5jzwx+r1KfBazie2HwTF9qDwOd8WBukEAwDc/UxFCJzoGt9TEbu4l0/SFhvSp5lDr/S1wfg=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@dcl/ui-env/-/ui-env-1.5.1.tgz",
+      "integrity": "sha512-03cPMH3wrNK5bdDEoidnXIr0ZpGPe0ly8ObDNwik6PjXF+g2YBAbo5/jDUN0panddL6N6YnCJROP8NkZl/ThnQ=="
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@dcl/schemas": "^11.9.0",
-    "@dcl/ui-env": "^1.4.0",
+    "@dcl/ui-env": "^1.5.1",
     "balloon-css": "^0.5.0",
     "classnames": "^2.3.2",
     "dayjs": "^1.11.10",


### PR DESCRIPTION
This PR upgrades `@dcl/ui-env` to fix an issue where it throws on runtime when it's used on a build that does not have `process` defined (like on Vite or esbuild or other bundlers with their out-of-the-box configuration).

For more info see https://github.com/decentraland/ui-env/pull/10